### PR TITLE
create multiple EP files per MAC address

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -400,7 +400,10 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 virtual_ips.append(
                     {'ip': aap['ip_address'],
                      'mac': aap.get('mac_address', mac)})
-        mapping_dict['ip'] = ips + ips_ext
+                if aap.get('active'):
+                    ips_ext.append(aap['ip_address'])
+        if ips or ips_ext:
+            mapping_dict['ip'] = sorted(ips + ips_ext)
         if virtual_ips:
             mapping_dict['virtual-ip'] = sorted(virtual_ips,
                                                 key=lambda x: x['ip'])

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -35,7 +35,6 @@ from oslo_serialization import jsonutils
 from opflexagent import as_metadata_manager
 from opflexagent import constants as ofcst
 from opflexagent import rpc
-from opflexagent import snat_iptables_manager
 
 eventlet_utils.monkey_patch()
 LOG = logging.getLogger(__name__)
@@ -274,15 +273,60 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                     port, net_uuid, network_type, physical_network,
                     segmentation_id, fixed_ips, device_owner, ovs_restarted)
         elif network_type in self.supported_pt_network_types:
+            # PT cleanup is needed before writing the new endpoint files
+            self.mapping_cleanup(port.vif_id, cleanup_vrf=False)
             if ((self.opflex_networks is None) or
                     (physical_network in self.opflex_networks)):
                 # Port has to be untagged due to a opflex agent requirement
                 self.int_br.clear_db_attribute("Port", port.port_name, "tag")
-                self.mapping_to_file(port, net_uuid, mapping, fixed_ips,
+                # Multiple files will be created based on how many MAC
+                # addresses are owned by the specific port.
+                mapping_copy = copy.deepcopy(mapping)
+                mac_active_aap = {}
+                mapping_copy['allowed_address_pairs'] = []
+                mapping_copy['floating_ip'] = []
+                fip_by_fixed = {}
+                # Prepare FIPs by fixed_ip
+                for fip in mapping.get('floating_ip', []):
+                    fip_by_fixed.setdefault(
+                        fip['fixed_ip_address'], []).append(fip)
+                for aap in mapping.get('allowed_address_pairs', []):
+                    if aap.get('active'):
+                        if not aap.get('mac_address'):
+                            # Should go with the MAIN mac address EP file
+                            mapping_copy['allowed_address_pairs'].append(aap)
+                            # Also set the right floating IPs
+                            mapping_copy['floating_ip'].extend(
+                                fip_by_fixed.get(aap['ip_address'], []))
+                        else:
+                            # Store for future processing
+                            mac_active_aap.setdefault(
+                                aap['mac_address'], []).append(aap)
+                # Create mapping file for base MAC address
+                self.mapping_to_file(port, net_uuid, mapping_copy, fixed_ips,
                                      device_owner)
+                # Reset for AAP EP files
+                mapping_copy['allowed_address_pairs'] = []
+                mapping_copy['fixed_ips'] = []
+                mapping_copy['extra_ips'] = []
+                mapping_copy['subnets'] = []
+                mapping_copy['enable_dhcp_optimization'] = False
+                mapping_copy['enable_metadata_optimization'] = False
+                # Map to file based on the active AAP with a MAC address
+                for mac, aaps in mac_active_aap:
+                    # Replace the MAC address with the new one
+                    mapping_copy['mac_address'] = mac
+                    # Extend the FIP list based on the allowed IPs
+                    mapping_copy['floating_ip'] = []
+                    mapping_copy['ip-address-mapping'] = []
+                    for aap in aaps:
+                        mapping_copy['floating_ip'].extend(fip_by_fixed.get(
+                            aap['ip_address'], []))
+                    # For this mac, set all the allowed address pairs.
+                    mapping_copy['allowed_address_pairs'] = aaps
+                    self.mapping_to_file(port, net_uuid, mapping_copy, None,
+                                         device_owner)
             else:
-                # PT cleanup may be needed
-                self.mapping_cleanup(port.vif_id)
                 LOG.error(_("Cannot provision OPFLEX network for "
                             "net-id=%(net_uuid)s - no bridge for "
                             "physical_network %(physical_network)s"),
@@ -312,18 +356,24 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
         if device_owner in [n_constants.DEVICE_OWNER_ROUTER_INTF]:
             return
         ips_ext = mapping.get('extra_ips') or []
-
+        mac = mapping.get('mac_address') or port.vif_mac
         mapping_dict = {
             "policy-space-name": mapping['ptg_tenant'],
             "endpoint-group-name": (mapping['app_profile_name'] + "|" +
                                     mapping['endpoint_group_name']),
             "interface-name": port.port_name,
-            "mac": mapping.get('mac_address') or port.vif_mac,
+            "mac": mac,
             "promiscuous-mode": mapping.get('promiscuous_mode') or False,
             "uuid": port.vif_id,
             'neutron-network': net_uuid}
 
-        ips = [x['ip_address'] for x in fixed_ips]
+        # Allocated IPs should be filtered by ownership.
+        if 'owned_addresses' in mapping:
+            ips = [x['ip_address'] for x in fixed_ips if
+                   x['ip_address'] in mapping['owned_addresses']]
+        else:
+            ips = [x['ip_address'] for x in fixed_ips]
+
         virtual_ips = []
         if device_owner == n_constants.DEVICE_OWNER_DHCP:
             # vm-name, if specified in mappings, will override this
@@ -354,7 +404,8 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
             mapping_dict['domain-name'] = mapping['vrf_name']
 
         self._fill_ip_mapping_info(port.vif_id, mapping, ips, mapping_dict)
-        self._write_endpoint_file(port.vif_id, mapping_dict)
+        # Create one file per MAC address.
+        self._write_endpoint_file(port.vif_id + '_' + mac, mapping_dict)
         self.vrf_info_to_file(mapping, vif_id=port.vif_id)
         if mapping.get('enable_metadata_optimization', False):
             self.metadata_mgr.ensure_initialized()
@@ -410,16 +461,16 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
             mapping_dict['dhcp6'] = {
                 'dns-servers': v6subnets[0]['dns_nameservers']}
 
-    def mapping_cleanup(self, vif_id):
+    def mapping_cleanup(self, vif_id, cleanup_vrf=True):
         LOG.debug('Cleaning mapping for vif id %s', vif_id)
-        self._delete_endpoint_file(vif_id)
+        self._delete_endpoint_files(vif_id)
         es = self._get_es_for_port(vif_id)
         self._dissociate_port_from_es(vif_id, es)
         self._release_int_fip(4, vif_id)
         self._release_int_fip(6, vif_id)
         vrf_id = self.vif_to_vrf.get(vif_id)
         vrf = self.vrf_dict.get(vrf_id)
-        if vrf:
+        if vrf and cleanup_vrf:
             del self.vif_to_vrf[vif_id]
             vrf['vifs'].discard(vif_id)
             if not vrf['vifs']:
@@ -515,6 +566,17 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
 
     def _delete_endpoint_file(self, port_id):
         return self._delete_file(port_id, self.epg_mapping_file)
+
+    def _delete_endpoint_files(self, port_id):
+        # Delete all files for this specific port_id
+        directory = os.path.dirname(self.epg_mapping_file)
+        # Remove all existing EPs mapping for port_id
+        for f in os.listdir(directory):
+            if f.endswith('.' + FILE_EXTENSION) and port_id in f:
+                try:
+                    os.remove(os.path.join(directory, f))
+                except OSError as e:
+                    LOG.exception(e)
 
     def _write_vrf_file(self, vrf_id, mapping_dict):
         return self._write_file(vrf_id, mapping_dict, self.vrf_mapping_file)

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -286,7 +286,7 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 # Multiple files will be created based on how many MAC
                 # addresses are owned by the specific port.
                 mapping_copy = copy.deepcopy(mapping)
-                mac_active_aap = {}
+                mac_aap_map = {}
                 mapping_copy['allowed_address_pairs'] = []
                 mapping_copy['floating_ip'] = []
                 fip_by_fixed = {}
@@ -296,7 +296,7 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                     fip_by_fixed.setdefault(
                         fip['fixed_ip_address'], []).append(fip)
                 # For the main MAC, set floating IP collection to all those
-                # FIPs pointing to the active Port fixed ips.
+                # FIPs pointing to the Port fixed ips.
                 for fixed in fixed_ips:
                     mapping_copy['floating_ip'].extend(
                         fip_by_fixed.get(fixed['ip_address'], []))
@@ -304,18 +304,17 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 # For the main MAC EP, set al the AAP with no mac address or
                 # MAC address equal to the original MAC.
                 for aap in mapping.get('allowed_address_pairs', []):
-                    if aap.get('active'):
-                        if not aap.get('mac_address') or aap.get(
-                                'mac_address') == original_mac:
-                            # Should go with the MAIN mac address EP file
-                            mapping_copy['allowed_address_pairs'].append(aap)
-                            # Also set the right floating IPs
-                            mapping_copy['floating_ip'].extend(
-                                fip_by_fixed.get(aap['ip_address'], []))
-                        else:
-                            # Store for future processing
-                            mac_active_aap.setdefault(
-                                aap['mac_address'], []).append(aap)
+                    if not aap.get('mac_address') or aap.get(
+                            'mac_address') == original_mac:
+                        # Should go with the MAIN mac address EP file
+                        mapping_copy['allowed_address_pairs'].append(aap)
+                        # Also set the right floating IPs
+                        mapping_copy['floating_ip'].extend(
+                            fip_by_fixed.get(aap['ip_address'], []))
+                    else:
+                        # Store for future processing
+                        mac_aap_map.setdefault(
+                            aap['mac_address'], []).append(aap)
                 # Create mapping file for base MAC address
                 self.mapping_to_file(port, net_uuid, mapping_copy, fixed_ips,
                                      device_owner)
@@ -326,13 +325,12 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 mapping_copy['subnets'] = []
                 mapping_copy['enable_dhcp_optimization'] = False
                 mapping_copy['enable_metadata_optimization'] = False
-                # Map to file based on the active AAP with a MAC address
-                for mac, aaps in mac_active_aap.iteritems():
+                # Map to file based on the AAP with a MAC address
+                for mac, aaps in mac_aap_map.iteritems():
                     # Replace the MAC address with the new one
                     mapping_copy['mac_address'] = mac
                     # Extend the FIP list based on the allowed IPs
                     mapping_copy['floating_ip'] = []
-                    mapping_copy['ip-address-mapping'] = []
                     for aap in aaps:
                         mapping_copy['floating_ip'].extend(fip_by_fixed.get(
                             aap['ip_address'], []))

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -327,7 +327,7 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 mapping_copy['enable_dhcp_optimization'] = False
                 mapping_copy['enable_metadata_optimization'] = False
                 # Map to file based on the active AAP with a MAC address
-                for mac, aaps in mac_active_aap:
+                for mac, aaps in mac_active_aap.iteritems():
                     # Replace the MAC address with the new one
                     mapping_copy['mac_address'] = mac
                     # Extend the FIP list based on the allowed IPs
@@ -401,10 +401,11 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
             if aap.get('ip_address'):
                 virtual_ips.append(
                     {'ip': aap['ip_address'],
-                     'mac': aap.get('mac_address', port.vif_mac)})
+                     'mac': aap.get('mac_address', mac)})
         mapping_dict['ip'] = ips + ips_ext
         if virtual_ips:
-            mapping_dict['virtual-ip'] = virtual_ips
+            mapping_dict['virtual-ip'] = sorted(virtual_ips,
+                                                key=lambda x: x['ip'])
 
         if 'vm-name' in mapping:
             mapping_dict['attributes'] = {'vm-name': mapping['vm-name']}

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -298,10 +298,8 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 # For the main MAC, set floating IP collection to all those
                 # FIPs pointing to the active Port fixed ips.
                 for fixed in fixed_ips:
-                    if fixed['ip_address'] in mapping.get(
-                            'owned_addresses', [fixed['ip_address']]):
-                        mapping_copy['floating_ip'].extend(
-                            fip_by_fixed.get(fixed['ip_address'], []))
+                    mapping_copy['floating_ip'].extend(
+                        fip_by_fixed.get(fixed['ip_address'], []))
 
                 # For the main MAC EP, set al the AAP with no mac address or
                 # MAC address equal to the original MAC.
@@ -383,12 +381,7 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
             "uuid": port.vif_id,
             'neutron-network': net_uuid}
 
-        # Allocated IPs should be filtered by ownership.
-        if 'owned_addresses' in mapping:
-            ips = [x['ip_address'] for x in fixed_ips if
-                   x['ip_address'] in mapping['owned_addresses']]
-        else:
-            ips = [x['ip_address'] for x in fixed_ips]
+        ips = [x['ip_address'] for x in fixed_ips]
 
         virtual_ips = []
         if device_owner == n_constants.DEVICE_OWNER_DHCP:

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -286,13 +286,25 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 mapping_copy['allowed_address_pairs'] = []
                 mapping_copy['floating_ip'] = []
                 fip_by_fixed = {}
+                original_mac = mapping.get('mac_address') or port.vif_mac
                 # Prepare FIPs by fixed_ip
                 for fip in mapping.get('floating_ip', []):
                     fip_by_fixed.setdefault(
                         fip['fixed_ip_address'], []).append(fip)
+                # For the main MAC, set floating IP collection to all those
+                # FIPs pointing to the active Port fixed ips.
+                for fixed in fixed_ips:
+                    if fixed['ip_address'] in mapping.get(
+                            'owned_addresses', [fixed['ip_address']]):
+                        mapping_copy['floating_ip'].extend(
+                            fip_by_fixed.get(fixed['ip_address'], []))
+
+                # For the main MAC EP, set al the AAP with no mac address or
+                # MAC address equal to the original MAC.
                 for aap in mapping.get('allowed_address_pairs', []):
                     if aap.get('active'):
-                        if not aap.get('mac_address'):
+                        if not aap.get('mac_address') or aap.get(
+                                'mac_address') == original_mac:
                             # Should go with the MAIN mac address EP file
                             mapping_copy['allowed_address_pairs'].append(aap)
                             # Also set the right floating IPs
@@ -324,7 +336,7 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                             aap['ip_address'], []))
                     # For this mac, set all the allowed address pairs.
                     mapping_copy['allowed_address_pairs'] = aaps
-                    self.mapping_to_file(port, net_uuid, mapping_copy, None,
+                    self.mapping_to_file(port, net_uuid, mapping_copy, [],
                                          device_owner)
             else:
                 LOG.error(_("Cannot provision OPFLEX network for "

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -181,14 +181,16 @@ class TestGbpOvsAgent(base.BaseTestCase):
                 "neutron-network": "net_id",
                 "domain-policy-space": 'apic_tenant',
                 "domain-name": 'name_of_l3p',
-                # 192.168.1.2 is not owned, won't be in the EP file
-                "ip": ['192.168.0.2', '192.169.8.1', '192.169.8.254'],
+                "ip": ['192.168.0.2', '192.168.1.2', '192.169.8.1',
+                       '192.169.8.254'],
                 # FIP mapping will be in the file
                 "ip-address-mapping": [{
                     'uuid': '1', 'mapped-ip': '192.168.0.2',
                     'floating-ip': '172.10.0.1',
                     'endpoint-group-name': 'profile_name|nat-epg-name',
-                    'policy-space-name': 'nat-epg-tenant'}]})
+                    'policy-space-name': 'nat-epg-tenant'},
+                    {'uuid': '2', 'mapped-ip': '192.168.1.2',
+                     'floating-ip': '172.10.0.2'}]})
 
         self.agent._write_vrf_file.assert_called_once_with(
             'l3p_id', {

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -309,8 +309,9 @@ class TestGbpOvsAgent(base.BaseTestCase):
                     "neutron-network": "net_id",
                     "domain-policy-space": 'apic_tenant',
                     "domain-name": 'name_of_l3p',
-                    "ip": ['192.168.0.2', '192.168.1.2', '192.169.8.1',
-                           '192.169.8.254'],
+                    # Also active AAPs are set
+                    "ip": ['192.168.0.2', '192.168.1.2', '192.169.0.4',
+                           '192.169.0.6', '192.169.8.1', '192.169.8.254'],
                     # FIP mapping will be in the file except for FIP 3 and 4
                     "ip-address-mapping": [{
                         'uuid': '1', 'mapped-ip': '192.168.0.2',
@@ -346,8 +347,8 @@ class TestGbpOvsAgent(base.BaseTestCase):
                     "neutron-network": "net_id",
                     "domain-policy-space": 'apic_tenant',
                     "domain-name": 'name_of_l3p',
-                    # No main IP address
-                    "ip": [],
+                    # Main IP address based on active AAP
+                    "ip": ['192.169.0.2', '192.169.0.7'],
                     # Only FIP number 4 here
                     "ip-address-mapping": [
                         {'uuid': '4', 'mapped-ip': '192.169.0.2',
@@ -371,7 +372,6 @@ class TestGbpOvsAgent(base.BaseTestCase):
                     "domain-policy-space": 'apic_tenant',
                     "domain-name": 'name_of_l3p',
                     # No main IP address
-                    "ip": [],
                     # Only FIP number 3 here
                     "ip-address-mapping": [
                         {'uuid': '3', 'mapped-ip': '192.169.0.1',

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -129,7 +129,9 @@ class TestGbpOvsAgent(base.BaseTestCase):
         return pattern
 
     def _port_bound_args(self, net_type='net_type'):
-        return {'port': mock.Mock(),
+        port = mock.Mock()
+        port.vif_id = uuidutils.generate_uuid()
+        return {'port': port,
                 'net_uuid': 'net_id',
                 'network_type': net_type,
                 'physical_network': 'phys_net',
@@ -152,12 +154,12 @@ class TestGbpOvsAgent(base.BaseTestCase):
             "Port", mock.ANY, "tag")
         self.assertFalse(self.agent.provision_local_vlan.called)
         self.agent._write_endpoint_file.assert_called_with(
-            args['port'].vif_id, {
+            args['port'].vif_id + '_' + mapping['mac_address'], {
                 "policy-space-name": mapping['ptg_tenant'],
                 "endpoint-group-name": (mapping['app_profile_name'] + "|" +
                                         mapping['endpoint_group_name']),
                 "interface-name": args['port'].port_name,
-                "mac": args['port'].vif_mac,
+                "mac": mapping['mac_address'],
                 "promiscuous-mode": mapping['promiscuous_mode'],
                 "uuid": args['port'].vif_id,
                 "attributes": {'vm-name': 'somename'},

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -124,7 +124,22 @@ class TestGbpOvsAgent(base.BaseTestCase):
                    'extra_ips': ['192.169.8.1', '192.169.8.254'],
                    'vrf_name': 'name_of_l3p',
                    'vrf_tenant': 'apic_tenant',
-                   'vrf_subnets': ['192.168.0.0/16', '192.169.0.0/16']}
+                   'vrf_subnets': ['192.168.0.0/16', '192.169.0.0/16'],
+                   'floating_ip': [{'id': '1',
+                                    'floating_ip_address': '172.10.0.1',
+                                    'floating_network_id': 'ext_net',
+                                    'router_id': 'ext_rout',
+                                    'port_id': 'port_id',
+                                    'fixed_ip_address': '192.168.0.2',
+                                    'nat_epg_tenant': 'nat-epg-tenant',
+                                    'nat_epg_name': 'nat-epg-name'},
+                                   {'id': '2',
+                                    'floating_ip_address': '172.10.0.2',
+                                    'floating_network_id': 'ext_net',
+                                    'router_id': 'ext_rout',
+                                    'port_id': 'port_id',
+                                    'fixed_ip_address': '192.168.1.2'}],
+                   'owned_addresses': ['192.168.0.2']}
         pattern.update(**kwargs)
         return pattern
 
@@ -166,8 +181,15 @@ class TestGbpOvsAgent(base.BaseTestCase):
                 "neutron-network": "net_id",
                 "domain-policy-space": 'apic_tenant',
                 "domain-name": 'name_of_l3p',
-                "ip": ['192.168.0.2', '192.168.1.2', '192.169.8.1',
-                       '192.169.8.254']})
+                # 192.168.1.2 is not owned, won't be in the EP file
+                "ip": ['192.168.0.2', '192.169.8.1', '192.169.8.254'],
+                # FIP mapping will be in the file
+                "ip-address-mapping": [{
+                    'uuid': '1', 'mapped-ip': '192.168.0.2',
+                    'floating-ip': '172.10.0.1',
+                    'endpoint-group-name': 'profile_name|nat-epg-name',
+                    'policy-space-name': 'nat-epg-tenant'}]})
+
         self.agent._write_vrf_file.assert_called_once_with(
             'l3p_id', {
                 "domain-policy-space": 'apic_tenant',

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -59,6 +59,17 @@ class TestGbpOvsAgent(base.BaseTestCase):
         self.addCleanup(self.agent.int_br.reset_mock)
         self.addCleanup(self.agent.of_rpc.get_gbp_details)
 
+    def _check_call_list(self, expected, observed, check_all=True):
+        for call in expected:
+            self.assertTrue(call in observed,
+                            msg='Call not found, expected:\n%s\nobserved:'
+                                '\n%s' % (str(call), str(observed)))
+            observed.remove(call)
+        if check_all:
+            self.assertFalse(
+                len(observed),
+                msg='There are more calls than expected: %s' % str(observed))
+
     def _purge_endpoint_dir(self):
         try:
             shutil.rmtree(self.ep_dir)
@@ -230,6 +241,111 @@ class TestGbpOvsAgent(base.BaseTestCase):
                 "domain-policy-space": 'apic_tenant',
                 "domain-name": 'name_of_l3p',
                 "internal-subnets": sorted(['192.170.0.0/16'])})
+
+    def test_port_multiple_ep_files(self):
+        self.agent.int_br = mock.Mock()
+        # Prepare AAP list
+        aaps = {'allowed_address_pairs': [
+            # Non active with MAC
+            {'ip_address': '192.169.0.1',
+             'mac_address': 'AA:AA'},
+            # Active with MAC
+            {'ip_address': '192.169.0.2',
+             'mac_address': 'BB:BB',
+             'active': True},
+            # Another address for this mac (BB:BB)
+            {'ip_address': '192.169.0.7',
+             'mac_address': 'BB:BB',
+             'active': True},
+            # Non active No MAC
+            {'ip_address': '192.169.0.3'},
+            # Active no MAC
+            {'ip_address': '192.169.0.4',
+             'active': True},
+            # Non active same MAC as main
+            {'ip_address': '192.169.0.5',
+             'mac_address': 'aa:bb:cc:00:11:22'},
+            # Active same MAC as main
+            {'ip_address': '192.169.0.6',
+             'mac_address': 'aa:bb:cc:00:11:22',
+             'active': True}]}
+        mapping = self._get_gbp_details(**aaps)
+        # Add a floating IPs
+        mapping['floating_ip'].extend([
+            # For non active with MAC AA:AA
+            {'id': '3', 'floating_ip_address': '172.10.0.3',
+             'floating_network_id': 'ext_net',
+             'router_id': 'ext_rout', 'port_id': 'port_id',
+             'fixed_ip_address': '192.169.0.1'},
+            # For active with MAC BB:BB
+            {'id': '4', 'floating_ip_address': '172.10.0.4',
+             'floating_network_id': 'ext_net',
+             'router_id': 'ext_rout', 'port_id': 'port_id',
+             'fixed_ip_address': '192.169.0.2'}])
+        self.agent.of_rpc.get_gbp_details.return_value = mapping
+        args = self._port_bound_args('opflex')
+        args['port'].gbp_details = mapping
+        self.agent.port_bound(**args)
+
+        # Build expected calls.
+        # Only 2 calls are expected, one for unique active MAC (BB:BB and main)
+        expected_calls = [
+            # First call, the main EP file is created.
+            mock.call(
+                args['port'].vif_id + '_' + mapping['mac_address'], {
+                    "policy-space-name": mapping['ptg_tenant'],
+                    "endpoint-group-name": (mapping['app_profile_name'] + "|" +
+                                            mapping['endpoint_group_name']),
+                    "interface-name": args['port'].port_name,
+                    "mac": 'aa:bb:cc:00:11:22',
+                    "promiscuous-mode": mapping['promiscuous_mode'],
+                    "uuid": args['port'].vif_id,
+                    "attributes": {'vm-name': 'somename'},
+                    "neutron-network": "net_id",
+                    "domain-policy-space": 'apic_tenant',
+                    "domain-name": 'name_of_l3p',
+                    "ip": ['192.168.0.2', '192.168.1.2', '192.169.8.1',
+                           '192.169.8.254'],
+                    # FIP mapping will be in the file except for FIP 3 and 4
+                    "ip-address-mapping": [{
+                        'uuid': '1', 'mapped-ip': '192.168.0.2',
+                        'floating-ip': '172.10.0.1',
+                        'endpoint-group-name': 'profile_name|nat-epg-name',
+                        'policy-space-name': 'nat-epg-tenant'},
+                        {'uuid': '2', 'mapped-ip': '192.168.1.2',
+                         'floating-ip': '172.10.0.2'}],
+                    # Set the proper allowed address pairs
+                    'virtual-ip': [{'ip': '192.169.0.4',
+                                    'mac': 'aa:bb:cc:00:11:22'},
+                                   {'ip': '192.169.0.6',
+                                    'mac': 'aa:bb:cc:00:11:22'}]}),
+            # Second call for MAC address BB:BB
+            mock.call(
+                args['port'].vif_id + '_' + 'BB:BB', {
+                    "policy-space-name": mapping['ptg_tenant'],
+                    "endpoint-group-name": (mapping['app_profile_name'] + "|" +
+                                            mapping['endpoint_group_name']),
+                    "interface-name": args['port'].port_name,
+                    # mac is BB:BB
+                    "mac": 'BB:BB',
+                    "promiscuous-mode": mapping['promiscuous_mode'],
+                    "uuid": args['port'].vif_id,
+                    "attributes": {'vm-name': 'somename'},
+                    "neutron-network": "net_id",
+                    "domain-policy-space": 'apic_tenant',
+                    "domain-name": 'name_of_l3p',
+                    # No main IP address
+                    "ip": [],
+                    # Only FIP number 4 here
+                    "ip-address-mapping": [
+                        {'uuid': '4', 'mapped-ip': '192.169.0.2',
+                         'floating-ip': '172.10.0.4'}],
+                    # Set the proper allowed address pairs with MAC BB:BB
+                    'virtual-ip': [{'ip': '192.169.0.2', 'mac': 'BB:BB'},
+                                   {'ip': '192.169.0.7', 'mac': 'BB:BB'}]})
+            ]
+        self._check_call_list(expected_calls,
+                              self.agent._write_endpoint_file.call_args_list)
 
     def test_port_unbound_delete_vrf_file(self):
         # Bind 2 ports on same VRF

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ oslo.utils<1.5.0,>=1.4.0 # Apache-2.0
 oslo.i18n<1.6.0,>=1.5.0 # Apache-2.0
 oslo.log<1.1.0,>=1.0.0 # Apache-2.0
 oslo.config<1.10.0,>=1.9.3 # Apache-2.0
-#pyinotify
+pyinotify

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ oslo.utils<1.5.0,>=1.4.0 # Apache-2.0
 oslo.i18n<1.6.0,>=1.5.0 # Apache-2.0
 oslo.log<1.1.0,>=1.0.0 # Apache-2.0
 oslo.config<1.10.0,>=1.9.3 # Apache-2.0
-pyinotify
+#pyinotify


### PR DESCRIPTION
allow_address_pairs extension in Neutron allows multiple MAC
addresses to exist for the same port. Create one EP file for each
MAC as per the opflex afgent specifications.