### PR TITLE
add extra details per mac address when needed

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -568,12 +568,15 @@ class GBPOvsAgent(ovs.OVSNeutronAgent):
                 skipped_devices.append(device)
                 continue
 
+            gbp_details = gbp_details_per_device.get(details['device'], {})
+            if gbp_details and 'port_id' not in gbp_details:
+                # The port is dead
+                details.pop('port_id', None)
             if 'port_id' in details:
                 LOG.info(_("Port %(device)s updated. Details: %(details)s"),
                          {'device': device, 'details': details})
                 # Inject GBP details
-                port.gbp_details = gbp_details_per_device.get(
-                    details['device'], {})
+                port.gbp_details = gbp_details
                 self.treat_vif_port(port, details['port_id'],
                                     details['network_id'],
                                     details['network_type'],

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -558,3 +558,15 @@ class TestGbpOvsAgent(base.BaseTestCase):
                                             '192.169.0.0/16',
                                             '1.1.1.0/24',
                                             '169.254.0.0/16'])})
+
+    def test_dead_port(self):
+        self.agent.of_rpc.get_gbp_details_list = mock.Mock(
+            return_value=[{'device': 'some_device'}])
+        self.agent.plugin_rpc.get_devices_details_list = mock.Mock(
+            return_value=[{'device': 'some_device', 'port_id': 'portid'}])
+        port = mock.Mock(ofport=1)
+        self.agent.int_br.get_vif_port_by_id = mock.Mock(return_value=port)
+        self.agent.port_dead = mock.Mock()
+
+        self.agent.treat_devices_added_or_updated(['some_device'], True)
+        self.agent.port_dead.assert_called_once_with(port)

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -286,6 +286,29 @@ class TestGbpOvsAgent(base.BaseTestCase):
             {'ip_address': '192.169.0.6',
              'mac_address': 'aa:bb:cc:00:11:22',
              'active': True}]}
+        # Prepare extra details for the AAPs
+        extra_details = {'BB:BB': {'extra_ips': ['192.170.0.1',
+                                                 '192.170.0.2'],
+                                   'floating_ip': [
+                                       {'id': '171',
+                                        'floating_ip_address': '173.10.0.1',
+                                        'floating_network_id': 'ext_net',
+                                        'router_id': 'ext_rout',
+                                        'port_id': 'port_id',
+                                        'fixed_ip_address': '192.170.0.1'}],
+                                   'ip_mapping': []},
+                         # AA won't be here because not active
+                         'aa:bb:cc:00:11:22': {
+                             'extra_ips': ['192.180.0.1', '192.180.0.2'],
+                             'floating_ip': [
+                                 {'id': '181',
+                                  'floating_ip_address': '173.11.0.1',
+                                  'floating_network_id': 'ext_net',
+                                  'router_id': 'ext_rout',
+                                  'port_id': 'port_id',
+                                  'fixed_ip_address': '192.180.0.1'}],
+                             'ip_mapping': []}}
+        aaps['extra_details'] = extra_details
         mapping = self._get_gbp_details(**aaps)
         # Add a floating IPs
         mapping['floating_ip'].extend([
@@ -328,13 +351,16 @@ class TestGbpOvsAgent(base.BaseTestCase):
                     "domain-name": 'name_of_l3p',
                     # Also active AAPs are set
                     "ip": ['192.168.0.2', '192.168.1.2', '192.169.0.4',
-                           '192.169.0.6', '192.169.8.1', '192.169.8.254'],
+                           '192.169.0.6', '192.169.8.1', '192.169.8.254',
+                           '192.180.0.1', '192.180.0.2'],
                     # FIP mapping will be in the file except for FIP 3 and 4
                     "ip-address-mapping": [{
                         'uuid': '1', 'mapped-ip': '192.168.0.2',
                         'floating-ip': '172.10.0.1',
                         'endpoint-group-name': 'profile_name|nat-epg-name',
                         'policy-space-name': 'nat-epg-tenant'},
+                        {'uuid': '181', 'mapped-ip': '192.180.0.1',
+                         'floating-ip': '173.11.0.1'},
                         {'uuid': '2', 'mapped-ip': '192.168.1.2',
                          'floating-ip': '172.10.0.2'},
                         {'uuid': '5', 'mapped-ip': '192.169.0.3',
@@ -368,9 +394,12 @@ class TestGbpOvsAgent(base.BaseTestCase):
                     "domain-policy-space": 'apic_tenant',
                     "domain-name": 'name_of_l3p',
                     # Main IP address based on active AAP
-                    "ip": ['192.169.0.2', '192.169.0.7'],
-                    # Only FIP number 4 here
+                    "ip": ['192.169.0.2', '192.169.0.7', '192.170.0.1',
+                           '192.170.0.2'],
+                    # Only FIP number 4 and 171 here
                     "ip-address-mapping": [
+                        {'uuid': '171', 'mapped-ip': '192.170.0.1',
+                         'floating-ip': '173.10.0.1'},
                         {'uuid': '4', 'mapped-ip': '192.169.0.2',
                          'floating-ip': '172.10.0.4'}],
                     # Set the proper allowed address pairs with MAC BB:BB


### PR DESCRIPTION
Use Case: Head of the chain is active and part of a cluster, all
the backend IP information must go to the right MAC address
(server will do the proper choice).