### PR TITLE
Changed 'awk' to 'gawk'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: git://github.com/noironetworks/python-opflex-agent.git
 
 Package: neutron-opflex-agent
 Architecture: all
-Depends: neutron-server (>=2015.1), python-pyinotify, supervisor,
+Depends: gawk, neutron-server (>=2015.1), python-pyinotify, supervisor,
          ${misc:Depends}, ${python:Depends}
 Description: Neutron agent for OpFlex based policy enforcement
  Neutron agent that provides edge policy enforcement

--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -610,7 +610,7 @@ class AsMetadataManager(object):
     def get_asport_mac(self):
         return self.sh(
             "ip netns exec %s ip link show %s | "
-            "awk -e '/link\/ether/ {print $2}'" %
+            "gawk -e '/link\/ether/ {print $2}'" %
             (SVC_NS, SVC_NS_PORT))
 
     def init_host(self, integ_br):

--- a/rpm/neutron-opflex-agent.spec.in
+++ b/rpm/neutron-opflex-agent.spec.in
@@ -11,6 +11,7 @@ BuildArch:	noarch
 BuildRequires:	python2-devel
 BuildRequires:	python-pbr
 BuildRequires:	python-setuptools
+Requires:	gawk
 Requires:	openstack-neutron >= 2015.1
 Requires:	openstack-neutron < 2015.2
 Requires:   python-inotify


### PR DESCRIPTION
Mirantis changed default awk from gawk to mawk creating compatibility
issues. Hence the change to explicitly use gawk.