### PR TITLE
Transiction refactored agent to asynchronous model

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -36,7 +36,15 @@ gbp_opts = [
     cfg.ListOpt('internal_floating_ip6_pool',
                default=['fe80::/64'],
                help=_("IPv6 pool used for intermediate floating-IPs "
-                      "with SNAT"))
+                      "with SNAT")),
+    cfg.IntOpt('endpoint_request_timeout', default=10,
+               help=_("Value in seconds that defines after how long the agent "
+                      "should reschedule port info on missing response.")),
+    cfg.IntOpt('config_apply_interval', default=0.5,
+               help=_("Value in seconds (fraction of a second is allowed as "
+                      "well) that defines how often the agent checks for RPC "
+                      "responses and applies them if any were received while "
+                      "in idle.")),
 ]
 
 cfg.CONF.register_opts(gbp_opts, "OPFLEX")

--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -37,7 +37,7 @@ class OpflexNotifyAgent(object):
         self.agent_id = 'opflex-notify-agent-%s' % self.host
         self.context = context.get_admin_context_without_session()
         self.sockname = OPFLEX_NOTIFY_SOCKNAME
-        self.of_rpc = opflexagent.gbp_ovs_agent.GBPOvsPluginApi(
+        self.of_rpc = opflexagent.rpc.GBPServerRpcApi(
             opflexagent.rpc.TOPIC_OPFLEX)
 
     def _handle(self, uuids, mac, addr):

--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -1,4 +1,3 @@
-
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
 #    a copy of the License at
@@ -20,11 +19,17 @@ import oslo_messaging
 LOG = logging.getLogger(__name__)
 
 TOPIC_OPFLEX = 'opflex'
+ENDPOINT = 'endpoint'
+VRF = 'vrf'
 
 
 class AgentNotifierApi(object):
+    """Server side notification API:
 
-    BASE_RPC_API_VERSION = '1.1'
+    - Version 1.2: add opflex update
+    """
+
+    BASE_RPC_API_VERSION = '1.2'
 
     def __init__(self, topic):
         target = oslo_messaging.Target(
@@ -36,6 +41,10 @@ class AgentNotifierApi(object):
                                                        topics.DELETE)
         self.topic_subnet_update = topics.get_topic_name(topic, topics.SUBNET,
                                                          topics.UPDATE)
+        self.topic_opflex_endpoint_update = topics.get_topic_name(
+            topic, TOPIC_OPFLEX, ENDPOINT, topics.UPDATE)
+        self.topic_opflex_vrf_update = topics.get_topic_name(
+            topic, TOPIC_OPFLEX, VRF, topics.UPDATE)
 
     def port_update(self, context, port):
         cctxt = self.client.prepare(fanout=True, topic=self.topic_port_update)
@@ -50,11 +59,24 @@ class AgentNotifierApi(object):
                                     topic=self.topic_subnet_update)
         cctxt.cast(context, 'subnet_update', subnet=subnet)
 
+    def opflex_endpoint_update(self, context, details, host=None):
+        cctxt = self.client.prepare(
+            fanout=True, topic=self.topic_opflex_endpoint_update, server=host)
+        cctxt.cast(context, 'opflex_endpoint_update', details=details)
 
-class GBPServerRpcApiMixin(object):
-    """Agent-side RPC (stub) for agent-to-plugin interaction."""
+    def opflex_vrf_update(self, context, details):
+        cctxt = self.client.prepare(fanout=True,
+                                    topic=self.topic_opflex_vrf_update)
+        cctxt.cast(context, 'opflex_vrf_update', details=details)
 
-    GBP_RPC_VERSION = "1.0"
+
+class GBPServerRpcApi(object):
+    """Agent-side RPC (stub) for agent-to-plugin interaction.
+
+    Version 1.1: add async request_* APIs
+    """
+
+    GBP_RPC_VERSION = "1.1"
 
     def __init__(self, topic):
         target = oslo_messaging.Target(
@@ -86,9 +108,44 @@ class GBPServerRpcApiMixin(object):
                           vrf_ids=vrf_ids, host=host)
 
     @log.log_method_call
+    def request_endpoint_details(self, context, agent_id, request=None,
+                                 host=None):
+        # Request is a tuple with the device_id as first element, and the
+        # request ID as second element
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
+        cctxt.cast(context, 'request_endpoint_details', agent_id=agent_id,
+                   request=request, host=host)
+
+    @log.log_method_call
+    def request_endpoint_details_list(self, context, agent_id, requests=None,
+                                      host=None):
+        # Requests is a list of tuples with the device_id as first element,
+        # and the request ID as second element
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
+        cctxt.cast(context, 'request_endpoint_details_list',
+                   agent_id=agent_id, requests=requests, host=host)
+
+    @log.log_method_call
+    def request_vrf_details(self, context, agent_id, request=None, host=None):
+        # Request is a tuple with the vrf_id as first element, and the
+        # request ID as second element
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
+        cctxt.cast(context, 'request_vrf_details', agent_id=agent_id,
+                   request=request, host=host)
+
+    @log.log_method_call
+    def request_vrf_details_list(self, context, agent_id, requests=None,
+                                 host=None):
+        # Requests is a list of tuples with the vrf_id as first element,
+        # and the request ID as second element
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
+        cctxt.cast(context, 'request_vrf_details_list',
+                   agent_id=agent_id, requests=requests, host=host)
+
+    @log.log_method_call
     def ip_address_owner_update(self, context, agent_id, ip_owner_info,
                                 host=None):
-        cctxt = self.client.prepare(fanout=True)
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
         cctxt.cast(context, 'ip_address_owner_update', agent_id=agent_id,
                    ip_owner_info=ip_owner_info, host=host)
 
@@ -98,12 +155,14 @@ class GBPServerRpcCallback(object):
 
     # History
     #   1.0 Initial version
+    #   1.1 Async request_* APIs
 
-    RPC_API_VERSION = "1.0"
+    RPC_API_VERSION = "1.1"
     target = oslo_messaging.Target(version=RPC_API_VERSION)
 
-    def __init__(self, gbp_driver):
+    def __init__(self, gbp_driver, agent_notifier=None):
         self.gbp_driver = gbp_driver
+        self.agent_notifier = agent_notifier
 
     def get_gbp_details(self, context, **kwargs):
         return self.gbp_driver.get_gbp_details(context, **kwargs)
@@ -131,14 +190,71 @@ class GBPServerRpcCallback(object):
             for vrf_id in kwargs.pop('vrf_ids', [])
         ]
 
+    def request_endpoint_details(self, context, **kwargs):
+        result = [self.gbp_driver.request_endpoint_details(context, **kwargs)]
+        # Notify the agent back once the answer is calculated
+        if result[0]:
+            self.agent_notifier.opflex_endpoint_update(
+                context, result, host=kwargs.get('host'))
+
+    def request_endpoint_details_list(self, context, **kwargs):
+        result = []
+        for request in kwargs.pop('requests', []):
+            details = self.gbp_driver.request_endpoint_details(
+                context, request=request, **kwargs)
+            if details:
+                result.append(details)
+
+        # Notify the agent back once the answer is calculated
+        # Exclude empty answers as an error as occurred and the agent might
+        # want to retry
+        if result:
+            self.agent_notifier.opflex_endpoint_update(
+                context, result, host=kwargs.get('host'))
+
+    def request_vrf_details(self, context, **kwargs):
+        result = [self.gbp_driver.request_vrf_details(context, **kwargs)]
+        # Notify the agent back once the answer is calculated
+        if result[0]:
+            self.agent_notifier.opflex_vrf_update(context, result,
+                                                  host=kwargs.get('host'))
+
+    def request_vrf_details_list(self, context, **kwargs):
+        result = []
+        for request in kwargs.pop('requests', []):
+            details = self.gbp_driver.request_vrf_details(
+                context, request=request, **kwargs)
+            if details:
+                result.append(details)
+
+        # Notify the agent back once the answer is calculated
+        # Exclude empty answers as an error as occurred and the agent might
+        # want to retry
+        if result:
+            self.agent_notifier.opflex_vrf_update(
+                context, [x for x in result if x], host=kwargs.get('host'))
+
     def ip_address_owner_update(self, context, **kwargs):
         self.gbp_driver.ip_address_owner_update(context, **kwargs)
 
 
-class GbpNeutronAgentRpcCallbackMixin(object):
+class OpenstackRpcMixin(object):
+    """A mix-in that enable Opflex agent
+    support in agent implementations.
+    """
+    target = oslo_messaging.Target(version='1.2')
+
+    def subnet_update(self, context, subnet):
+        self.updated_vrf.add(subnet['tenant_id'])
+        LOG.debug("subnet_update message processed for subnet %s",
+                  subnet['id'])
 
     def port_update(self, context, **kwargs):
         port = kwargs.get('port')
+        # Put the port identifier in the updated_ports set.
+        # Even if full port details might be provided to this call,
+        # they are not used since there is no guarantee the notifications
+        # are processed in the same order as the relevant API requests
         self.updated_ports.add(port['id'])
         LOG.debug("port_update message processed for port %s", port['id'])
 
@@ -147,10 +263,8 @@ class GbpNeutronAgentRpcCallbackMixin(object):
         self.deleted_ports.add(port_id)
         LOG.debug("port_delete message processed for port %s", port_id)
 
-    def network_delete(self, context, **kwargs):
-        pass
+    def opflex_endpoint_update(self, context, details):
+        self._opflex_endpoint_update(context, details)
 
-    def subnet_update(self, context, subnet):
-        self.updated_vrf.add(subnet['tenant_id'])
-        LOG.debug("subnet_update message processed for subnet %s",
-                  subnet['id'])
+    def opflex_vrf_update(self, context, details):
+        self._opflex_vrf_update(self, context, details)

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -1,0 +1,208 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sys
+
+import mock
+sys.modules["apicapi"] = mock.Mock()
+sys.modules["pyinotify"] = mock.Mock()
+
+from opflexagent import gbp_ovs_agent
+from opflexagent.utils.port_managers import async_port_manager
+
+from neutron.agent.dhcp import config as dhcp_config
+from neutron.tests import base
+from oslo_config import cfg
+from oslo_utils import uuidutils
+
+_uuid = uuidutils.generate_uuid
+EP_DIR = '.%s_endpoints/'
+
+
+class TestAsyncPortManager(base.BaseTestCase):
+
+    def setUp(self):
+        cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+        super(TestAsyncPortManager, self).setUp()
+        cfg.CONF.set_default('quitting_rpc_timeout', 10, 'AGENT')
+        cfg.CONF.set_default('endpoint_request_timeout', 10000, 'OPFLEX')
+        self.manager = self._initialize_agent()
+        self.agent = self.manager.gbp_agent
+        self.manager.pending_requests_by_request_id = (
+            self.manager.pending_requests._pending_requests_by_request_id)
+        self.manager.pending_requests_by_device_id = (
+            self.manager.pending_requests._pending_requests_by_device_id)
+
+    def _check_call_list(self, expected, observed, check_all=True):
+        for call in expected:
+            self.assertTrue(call in observed,
+                            msg='Call not found, expected:\n%s\nobserved:'
+                                '\n%s' % (str(call), str(observed)))
+            observed.remove(call)
+        if check_all:
+            self.assertFalse(
+                len(observed),
+                msg='There are more calls than expected: %s' % str(observed))
+
+    def _initialize_agent(self):
+        kwargs = gbp_ovs_agent.create_agent_config_map(cfg.CONF)
+        agent = async_port_manager.AsyncPortManager().initialize(
+            'h1', mock.Mock(), kwargs)
+        agent.of_rpc = mock.Mock()
+        return agent
+
+    def _expire_update(self, ports_to_expire):
+        for device in ports_to_expire:
+            # Same reference is in the by_request_id dictionary
+            self.manager.pending_requests_by_device_id[device]['timestamp'] = (
+                -1)
+
+    def _sort_requests(self, requests):
+        return sorted(requests, key=lambda x: x['request_id'])
+
+    def _get_device_requests(self, devices):
+        return [self.manager.pending_requests_by_device_id[x] for x in devices]
+
+    def test_initialized(self):
+        self.assertEqual(10000, self.manager.request_timeout)
+
+    def test_schedule_update(self):
+        # There are no pending nor new requests, nothing happens
+        self.manager.schedule_update()
+        self.assertEqual(
+            0, self.manager.of_rpc.request_endpoint_details_list.call_count)
+
+        # Set new updates
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        self.assertEqual(4, len(self.manager.pending_requests_by_request_id))
+        self.assertEqual(4, len(self.manager.pending_requests_by_device_id))
+        self.assertEqual(
+            to_schedule,
+            set(self.manager.pending_requests_by_device_id.keys()))
+        self.assertEqual(
+            set([x['request_id'] for x in
+                 self.manager.pending_requests_by_device_id.values()]),
+            set(self.manager.pending_requests_by_request_id.keys()))
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self.manager.pending_requests_by_request_id.values())))
+
+        self.manager.of_rpc.reset_mock()
+        # The updates expired
+        self._expire_update(ports_to_expire=set(['1', '3']))
+        # Verify updates are reapplied
+        self.manager.schedule_update(set())
+        # timestamp refreshed and call reissued
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['1']['timestamp'])
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['3']['timestamp'])
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self._get_device_requests(['1', '3']))))
+
+        self.manager.of_rpc.reset_mock()
+        # Verify expired and new ports requests
+        self._expire_update(set(['2', '4']))
+        self.manager.schedule_update(set(['5']))
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['2']['timestamp'])
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['4']['timestamp'])
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self._get_device_requests(['2', '4', '5']))))
+
+    def test_opflex_update(self):
+        # Set up some requests
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+
+        # Verify answer to some of them
+        update = self._get_device_requests(['1', '3'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        # Still pending until configuration apply happens
+        self.assertTrue(
+            '1' in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '3' in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            update[0]['request_id'] in
+            self.manager.pending_requests_by_request_id)
+        self.assertTrue(
+            update[1]['request_id'] in
+            self.manager.pending_requests_by_request_id)
+        self.assertTrue('1' in self.manager.response_by_device_id)
+        self.assertTrue('3' in self.manager.response_by_device_id)
+
+        # Ignore update
+        update[0]['request_id'] = 'stuff'
+        update[0]['device'] = '5'
+        self.manager._opflex_endpoint_update(mock.Mock(), update[:1])
+        # Update was ignored
+        self.assertTrue('5' not in self.manager.response_by_device_id)
+
+    def test_apply_config(self):
+        self.agent.treat_devices_added_or_updated = mock.Mock(
+            return_value=True)
+
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '2', '4'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        expected_calls = [mock.call(self.manager.response_by_device_id[x])
+                          for x in ['1', '2', '4']]
+        self.manager.apply_config()
+        # Removed from pending requests
+        self.assertTrue(
+            '1' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '2' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '4' not in self.manager.pending_requests_by_device_id)
+        self._check_call_list(
+            expected_calls,
+            self.agent.treat_devices_added_or_updated.call_args_list)
+        self.assertEqual({}, self.manager.response_by_device_id)
+
+    def test_apply_config_fails(self):
+        self.agent.treat_devices_added_or_updated = mock.Mock(
+            side_effect=Exception)
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '2', '4'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        self.assertRaises(Exception, self.manager.apply_config)
+        # responses are restored after the exception
+        self.assertEqual(3, len(self.manager.response_by_device_id))
+
+    def test_unschedule_update(self):
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '3'])
+        self.manager.unschedule_update(set(['1', '3']))
+        self.assertTrue('1' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue('3' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(update[0]['request_id'] not in
+                        self.manager.pending_requests_by_request_id)
+        self.assertTrue(update[1]['request_id'] not in
+                        self.manager.pending_requests_by_request_id)

--- a/opflexagent/test/test_rpc.py
+++ b/opflexagent/test/test_rpc.py
@@ -1,0 +1,99 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sys
+
+import mock
+sys.modules["apicapi"] = mock.Mock()
+sys.modules["pyinotify"] = mock.Mock()
+
+from opflexagent import rpc
+from opflexagent.test import base
+
+
+class TestOpflexRpc(base.OpflexTestBase):
+
+    def setUp(self):
+        super(TestOpflexRpc, self).setUp()
+        self.callback = rpc.GBPServerRpcCallback(mock.Mock(), mock.Mock())
+
+    def test_request_endpoint_details(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details(mock.ANY, host='h1')
+        (self.callback.agent_notifier.opflex_endpoint_update.
+            assert_called_once_with(mock.ANY, [result], host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_endpoint_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details(mock.ANY, host='h1')
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_endpoint_update.called)
+
+    def test_request_vrf_details(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details(mock.ANY, host='h1')
+        (self.callback.agent_notifier.opflex_vrf_update.
+            assert_called_once_with(mock.ANY, [result], host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_vrf_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details(mock.ANY, host='h1')
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_vrf_update.called)
+
+    def test_request_endpoint_details_list(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        (self.callback.agent_notifier.opflex_endpoint_update.
+            assert_called_once_with(mock.ANY, [result] * 3, host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_endpoint_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_endpoint_update.called)
+
+    def test_request_vrf_details_list(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        (self.callback.agent_notifier.opflex_vrf_update.
+            assert_called_once_with(mock.ANY, [result] * 3, host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_vrf_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_vrf_update.called)

--- a/opflexagent/test/test_type_opflex.py
+++ b/opflexagent/test/test_type_opflex.py
@@ -13,8 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from neutron.plugins.ml2 import config
+from neutron.common import config as nconfig  # noqa
+from neutron.plugins.ml2 import config  # noqa
 from neutron.tests.unit import testlib_api
+from oslo_config import cfg
 
 from opflexagent import config as ofconf  # noqa
 from opflexagent import type_opflex
@@ -23,34 +25,34 @@ from opflexagent import type_opflex
 OPFLEX_NETWORKS = ['opflex_net1', 'opflex_net2']
 
 
-class FlatTypeTest(testlib_api.SqlTestCase):
+class OpflexTypeTest(testlib_api.SqlTestCase):
 
     def setUp(self):
-        super(FlatTypeTest, self).setUp()
-        config.cfg.CONF.set_override('opflex_networks', OPFLEX_NETWORKS,
-                                     group='OPFLEX')
+        super(OpflexTypeTest, self).setUp()
+        cfg.CONF.set_override('opflex_networks', OPFLEX_NETWORKS,
+                              group='OPFLEX')
         self.driver = type_opflex.OpflexTypeDriver()
 
     def test_physnet_mtus_initiated(self):
         self.assertIsNotNone(getattr(self.driver, 'physnet_mtus', None))
 
     def test_get_mtu(self):
-        config.cfg.CONF.set_override('global_physnet_mtu', 1475)
-        config.cfg.CONF.set_override('path_mtu', 1400, group='ml2')
+        cfg.CONF.set_override('global_physnet_mtu', 1475)
+        cfg.CONF.set_override('path_mtu', 1400, group='ml2')
         self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
         self.assertEqual(1450, self.driver.get_mtu('physnet1'))
 
-        config.cfg.CONF.set_override('global_physnet_mtu', 1375)
-        config.cfg.CONF.set_override('path_mtu', 1400, group='ml2')
+        cfg.CONF.set_override('global_physnet_mtu', 1375)
+        cfg.CONF.set_override('path_mtu', 1400, group='ml2')
         self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
         self.assertEqual(1375, self.driver.get_mtu('physnet1'))
 
-        config.cfg.CONF.set_override('global_physnet_mtu', 0)
-        config.cfg.CONF.set_override('path_mtu', 1425, group='ml2')
+        cfg.CONF.set_override('global_physnet_mtu', 0)
+        cfg.CONF.set_override('path_mtu', 1425, group='ml2')
         self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
         self.assertEqual(1400, self.driver.get_mtu('physnet2'))
 
-        config.cfg.CONF.set_override('global_physnet_mtu', 0)
-        config.cfg.CONF.set_override('path_mtu', 0, group='ml2')
+        cfg.CONF.set_override('global_physnet_mtu', 0)
+        cfg.CONF.set_override('path_mtu', 0, group='ml2')
         self.driver.physnet_mtus = {}
         self.assertEqual(0, self.driver.get_mtu('physnet1'))

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -1,0 +1,171 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+
+from neutron.agent import rpc as agent_rpc
+from neutron.common import topics
+from neutron import context
+from neutron.i18n import _LE, _LI, _LW  # noqa
+from oslo_log import log as logging
+from oslo_utils import excutils
+from oslo_utils import uuidutils
+
+from opflexagent import rpc
+from opflexagent.utils.port_managers import port_manager_base as base
+
+LOG = logging.getLogger(__name__)
+
+
+class RequestMap(object):
+
+    def __init__(self):
+        self._pending_requests_by_device_id = {}
+        self._pending_requests_by_request_id = {}
+
+    def get_by_device_id(self, device_id):
+        return self._pending_requests_by_device_id.get(device_id)
+
+    def get_by_request_id(self, request_id):
+        return self._pending_requests_by_request_id.get(request_id)
+
+    def get_requests(self):
+        return self._pending_requests_by_request_id.values()
+
+    def update_request(self, request):
+        # Add or replace
+        # Remove current requests if any
+        self.pop_by_device_id(request['device'])
+        # Replace with new requests
+        self._pending_requests_by_device_id[request['device']] = request
+        self._pending_requests_by_request_id[request['request_id']] = request
+
+    def pop_by_request_id(self, request_id):
+        current_request = self._pending_requests_by_request_id.pop(
+            request_id, {})
+        self._pending_requests_by_device_id.pop(
+            current_request.get('device'), None)
+        return current_request or None
+
+    def pop_by_device_id(self, device_id):
+        current_request = self._pending_requests_by_device_id.pop(device_id,
+                                                                  {})
+        self._pending_requests_by_request_id.pop(
+            current_request.get('request_id'), None)
+        return current_request or None
+
+
+class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
+    """ Async Port Manager
+
+    Uses asynchronous RPC APIs to retrieve information from the Neutron server.
+    """
+
+    def initialize(self, host, gbp_agent, config):
+        self.agent_id = gbp_agent.agent_id
+        self.gbp_agent = gbp_agent
+        self._setup_rpc()
+        self.pending_requests = RequestMap()
+        self.response_by_device_id = {}
+        self.request_timeout = config['endpoint_request_timeout']
+        self.host = host
+        return self
+
+    def apply_config(self):
+        skipped = []
+        response_by_device_id_copy = self.response_by_device_id
+        self.response_by_device_id = {}
+        try:
+            for details in response_by_device_id_copy.values():
+                # Context switch might happen here
+                if not self.gbp_agent.treat_devices_added_or_updated(details):
+                    skipped.append(details['device'])
+                # Remove the request after a configuration write without
+                # errors. Leaving the request pending is useful in case of
+                # exceptions raised by the method above, since timeout will
+                # eventually kick in and the port will go to the right state.
+                self.pending_requests.pop_by_request_id(details['request_id'])
+        except Exception as e:
+            LOG.debug("An exception has occurred.")
+            with excutils.save_and_reraise_exception():
+                # The upper layers will trigger the resync
+                LOG.error(_LE("Configuration failed on port manager: %s"),
+                          e.message)
+                # Newer responses take precedence over old ones.
+                response_by_device_id_copy.update(self.response_by_device_id)
+                self.response_by_device_id = response_by_device_id_copy
+        return skipped
+
+    def schedule_update(self, device_ids=None):
+        current_time = int(round(time.time() * 1000))
+        device_ids = set(device_ids or [])
+        LOG.debug('Update initially scheduled for port ids %s', device_ids)
+        # See if more ports need to be updated due to request timeout
+        for request in self.pending_requests.get_requests():
+            if current_time - request['timestamp'] > self.request_timeout:
+                LOG.info(_LI('Request %s has timed out, rescheduling'),
+                         request['request_id'])
+                device_ids.add(request['device'])
+                # Remove from the pending requests, concurrency is not a
+                # concern because of how greenthreads work
+                self.pending_requests.pop_by_request_id(request['request_id'])
+
+        LOG.info(_LI('Update scheduled for port ids %s'), device_ids)
+        requests = []
+        for device_id in device_ids:
+            request = {'request_id': uuidutils.generate_uuid(),
+                       'timestamp': current_time, 'device': device_id}
+            requests.append(request)
+            self.pending_requests.update_request(request)
+
+        LOG.debug('Scheduled requests: %s', requests)
+        if requests:
+            self.of_rpc.request_endpoint_details_list(
+                self.context, agent_id=self.agent_id,
+                requests=sorted(requests, key=lambda x: x['request_id']),
+                host=self.host)
+
+    def unschedule_update(self, device_ids=None):
+        LOG.info(_LI("Unschedule update request for devices %s"), device_ids)
+        for device_id in device_ids:
+            self.pending_requests.pop_by_device_id(device_id)
+
+    def _setup_rpc(self):
+        self.context = context.get_admin_context_without_session()
+        # Set GBP rpc API
+        self.of_rpc = rpc.GBPServerRpcApi(rpc.TOPIC_OPFLEX)
+        self.topic = topics.AGENT
+        self.endpoints = [self]
+        consumers = [[rpc.TOPIC_OPFLEX, rpc.ENDPOINT, topics.UPDATE]]
+        self.connection = agent_rpc.create_consumers(
+            self.endpoints, self.topic, consumers, start_listening=True)
+
+    def _opflex_endpoint_update(self, context, details):
+        # Don't worry about concurrency, greenthreads won't be scheduled until
+        # an explicit IO call is perfomed.
+        LOG.info(_LI('Got endpoint update from the server'))
+        LOG.debug('The following updates were received: %s', details)
+        for detail in details:
+            if 'request_id' in detail:
+                if not self.pending_requests.get_by_request_id(
+                        detail['request_id']):
+                    # This is a old request, ignore.
+                    LOG.debug(
+                        'Ignoring update with request ID %s as it is not '
+                        'in the pending list', detail['request_id'])
+                    continue
+                self.response_by_device_id[detail['device']] = detail
+            LOG.debug("Got response for port %(port_id)s in "
+                      "%(secs)s seconds",
+                      {'port_id': detail.get('device'),
+                       'secs': ((time.time() * 1000) -
+                                float(detail.get('timestamp', 0)))})

--- a/opflexagent/utils/port_managers/port_manager_base.py
+++ b/opflexagent/utils/port_managers/port_manager_base.py
@@ -1,0 +1,62 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class PortManagerBase(object):
+    """ Port Manager base class
+
+    Defines an interface between the GBP opflex Agent and the Neutron server.
+    The port manager takes care of requesting and processing Neutron's ports
+    related info. Uses the gbp_agent for applying ports' configuration.
+    """
+
+    @abc.abstractmethod
+    def initialize(self, host, gbp_agent, config):
+        """ Port Manager initialization method.
+
+        This method will be called before any other.
+
+        :param host: agent host
+        :param gbp_agent: the gbp agent handler.
+        :param config: configuration dictionary
+
+        :returns: self
+        """
+
+    def apply_config(self):
+        """ Apply Port config.
+
+        Applies currently stored configuration to the datapath, using the
+        gbp agent.
+
+        :returns: list of skipper devices
+        """
+
+    def schedule_update(self, port_ids=None):
+        """ Schedule port updates.
+
+        Old unattended requests should be handled here as well
+
+        :param port_ids: ports for which update is needed
+        """
+
+    def unschedule_update(self, port_ids=None):
+        """ Unchedule port updates.
+
+        Used in case of deleted or removed ports
+
+        :param port_ids: ports for which update is not needed anymore
+        """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ oslo.utils!=2.6.0,>=2.0.0 # Apache-2.0
 oslo.i18n>=2.1.0 # Apache-2.0
 oslo.log>=1.8.0 # Apache-2.0
 oslo.config>=2.3.0 # Apache-2.0
-pyinotify
+#pyinotify

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands = {posargs}
 # H405 multi line docstring summary not separated with an empty line
 # H904 Wrap long lines in parentheses instead of a backslash
 # TODO(marun) H404 multi line docstring should start with a summary
-ignore = H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
+ignore = H202,H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
 show-source = true
 builtins = _
 exclude = .venv,.git,.tox,dist,doc,*openstack/common*,*neutron/common*,*lib/python*,*egg,build,tools,.ropeproject,rally-scenarios


### PR DESCRIPTION
- Introduce Port Manager. This module takes care of managing
the async comunication between Neutron and the Opflex Agent
- Switch to the request_* RPC calls.

To avoid increasing the chance of conflicts even further, some
of the methods currently on the main agent class were not moved
to the port manager. This will be done eventually.