### PR TITLE
Added support for DVS/OVS OpFlex Agent

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -30,6 +30,16 @@ gbp_opts = [
                 default=['*'],
                 help=_("List of the physical networks managed by this agent. "
                        "Use * for binding any opflex network to this agent")),
+    cfg.ListOpt('firewall_map',
+                default=[('dvs_port_key',
+                    'opflexagent.utils.fw_drivers.dvs.DVSFirewallDriver'), ],
+                help=_("List of tuples containing firewall driver and the "
+                       "key that selects it")),
+    cfg.StrOpt('hypervisor_type',
+               default='KVM',
+               help=_("Hypervisor of the host running this agent. Only needed "
+                      "on hosts running nova-compute. Set to 'VMware vCenter' "
+                      "for hosts running nova-compute for vCenter")),
     cfg.ListOpt('internal_floating_ip_pool',
                default=['169.254.0.0/16'],
                help=_("IP pool used for intermediate floating-IPs with SNAT")),

--- a/opflexagent/constants.py
+++ b/opflexagent/constants.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 AGENT_TYPE_OPFLEX_OVS = 'OpFlex Open vSwitch agent'
+# TODO(tbachman) Figure out a better/common place for this
+HYPERVISOR_VCENTER = "VMware vCenter"
 TYPE_OPFLEX = 'opflex'
 
 METADATA_DEFAULT_IP = '169.254.169.254'

--- a/opflexagent/firewall_wrapper.py
+++ b/opflexagent/firewall_wrapper.py
@@ -1,0 +1,115 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+from oslo_utils import importutils
+
+
+LOG = logging.getLogger(__name__)
+
+
+class FirewallDriverWrapper(object):
+    """Wrapper for Firewall Driver implemntations
+
+    This wrapper class keeps a map of drivers to use for
+    implementing a firewall driver. The firewall driver methods
+    are divided into two groups:
+      1) methods where only one driver implementation should be called
+      2) methods where all driver implementations should be called
+
+    The first group is called when there is only a single argument:
+    the neutron port. The second group is called in all other cases.
+    The first group uses a key to determine which driver gets invoked.
+    The key is obtained by a user-defined strategy function, which gets
+    passed the port object. The strategy function is meant to perform
+    some operation (e.g. search) on the port to determine and return
+    the key to use for looking up the appropriate firewall driver.
+
+    There is also a defaulit firewall driver. This is used when there
+    is only a single firewall driver is used, and therefore a key is
+    not needed.
+    """
+
+    def __init__(self):
+        self._strategy_map = {}
+        self._strategy_fn = None
+        self._default_strategy = None
+        self._port_methods = ['prepare_port_filter',
+                              'apply_port_filter',
+                              'update_port_filter',
+                              'remove_port_filter']
+        self._all_strategy_methods = ['filter_defer_apply_on',
+                                      'filter_defer_apply_off',
+                                      'ports',
+                                      'defer_apply',
+                                      'update_security_group_members',
+                                      'update_security_group_rules']
+
+    def _do_port_strategy(self, name, port, *p_args, **p_kwargs):
+        """Call a single firewall driver method"""
+        strategy_obj = self._default_strategy
+        if self._strategy_map and self._strategy_fn:
+            key = self._strategy_fn(port, self._strategy_map)
+            if key:
+                strategy_obj = self._strategy_map[key]
+        return getattr(strategy_obj, name)(port)
+
+    def _do_all_strategy(self, name, *s_args, **s_kwargs):
+        """Call all the firewall driver methods"""
+        if self._default_strategy:
+            return getattr(self._default_strategy, name)(*s_args, **s_kwargs)
+        else:
+            ret_list = []
+            for driver in self._strategy_map.values():
+                ret_list.append(getattr(driver, name)(*s_args, **s_kwargs))
+            return ret_list
+
+    def __getattr__(self, name):
+        def _do_strategy(*args, **kwargs):
+            """Invoke the appropiate strategy method
+
+            This checks whether the method is in the port-based
+            methods or non-port-based methods, and invokes the
+            appropriate strategy. If it's not a valid method,
+            it raises AttributeError
+            """
+            if name in self._port_methods:
+                return self._do_port_strategy(name, *args, **kwargs)
+            elif name in self._all_strategy_methods:
+                return self._do_all_strategy(name, *args, **kwargs)
+            else:
+                raise AttributeError
+        return _do_strategy
+
+    def set_strategy_and_map(self, strategy_map, strategy_fn, default):
+        """Set Firewall Driver strategy and map
+
+           This sets the strategy to call when selecting
+           which firewall driver to use. It also provides
+           a list of tuples, which are turned into a map
+           of security group objects/implementations, indexed
+           by their keys.
+        """
+        if not strategy_map and default is None:
+            return
+
+        # set default strategy if a map wasn't provided
+        if not strategy_map:
+            self._default_strategy = importutils.import_object(default)
+
+        self._strategy_fn = strategy_fn
+
+        # We need to go through and load each of the classes
+        # in the firewall map and provide that in our map
+        for element in strategy_map:
+            key, value = element
+            self._strategy_map[key] = importutils.import_object(value)

--- a/opflexagent/test/test_fw_wrapper.py
+++ b/opflexagent/test/test_fw_wrapper.py
@@ -1,0 +1,389 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import contextlib
+import mock
+
+from opflexagent import gbp_ovs_agent
+
+from neutron.agent.dhcp import config as dhcp_config
+from neutron.agent import firewall
+from neutron.tests import base
+from oslo_config import cfg
+from oslo_utils import uuidutils
+
+_uuid = uuidutils.generate_uuid
+EP_DIR = '.%s_endpoints/'
+TENANTID1 = "footenant"
+NETID1 = "foonet1"
+SUBNETID1 = "foosubnet1"
+SECGROUP1 = "foosecgroup1"
+SECGROUP2 = "foosecgroup2"
+port1 = ({"status": "DOWN",
+          "name": "private-port",
+          "allowed_address_pairs": [],
+          "admin_state_up": True,
+          "network_id": NETID1,
+          "tenant_id": TENANTID1,
+          "device_owner": "",
+          "mac_address": "fa:16:3e:c9:cb:f0",
+          "binding:vif_details": {
+              "port_filter": True,
+              "dvs_port_group": "bar"
+          },
+          "binding:vnic_type": "normal",
+          "binding:vif_type": "unbound",
+          "fixed_ips": [{
+              "subnet_id": SUBNETID1,
+              "ip_address": "10.0.0.2"}
+          ],
+          "id": "fooid1",
+          "security_groups": [SECGROUP1],
+          "device_id": ""})
+
+port2 = ({"status": "DOWN",
+          "binding:host_id": "",
+          "allowed_address_pairs": [],
+          "extra_dhcp_opts": [],
+          "device_owner": "",
+          "binding:profile": {},
+          "fixed_ips": [{
+              "subnet_id": SUBNETID1,
+              "ip_address": "10.0.0.3"}
+          ],
+          "id": "fooid2",
+          "security_groups": [SECGROUP2],
+          "device_id": "",
+          "name": "pt_esx_vm1_gbpui",
+          "admin_state_up": True,
+          "network_id": NETID1,
+          "tenant_id": TENANTID1,
+          "binding:vif_details": {
+              "port_filter": True,
+              "foo_key": "bar"
+          },
+          "binding:vnic_type": "normal",
+          "binding:vif_type": "unbound",
+          "mac_address": "fa:16:3e:db:e9:0e"})
+
+sg_id1 = "foosecuritygroup"
+sg_rule1 = {"foo_rule1": "rule"}
+sg_members1 = ["foomember1", "foomember2"]
+
+
+class FakeFw1(firewall.FirewallDriver):
+    def prepare_port_filter(self, port):
+        pass
+
+    def apply_port_filter(self, port):
+        pass
+
+    def update_port_filter(self, port):
+        pass
+
+    def remove_port_filter(self, port):
+        pass
+
+    @property
+    def ports(self):
+        return None
+
+    def update_security_group_rules(self, sg_id, sg_rules):
+        pass
+
+    def update_security_group_members(self, sg_id, sg_members):
+        pass
+
+    def filter_defer_apply_on(self):
+        pass
+
+    def filter_defer_apply_off(self):
+        pass
+
+
+class FakeFw2(FakeFw1):
+    def __init__(self):
+        pass
+
+
+class FakeFw3(FakeFw1):
+    def __init__(self):
+        pass
+
+
+class TestFirewallWrapperBase(base.BaseTestCase):
+    """Base class for firewall tests
+
+       This is a base class for firewall wrapper testing.
+       It doesn't implement any tests itself, but provides
+       the common functionality needed by derived classes.
+    """
+    def setUp(self):
+        super(TestFirewallWrapperBase, self).setUp()
+        self.agent = self._initialize_agent()
+
+    def _initialize_agent_config(self):
+        """Config file initialization -- specialize as needed"""
+        cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+        cfg.CONF.set_override('firewall_map',
+            [('dvs_port_key',
+            'opflexagent.test.test_fw_wrapper.FakeFw1'),
+             ('foo_key',
+            'opflexagent.test.test_fw_wrapper.FakeFw2'), ], 'OPFLEX')
+        cfg.CONF.set_default('firewall_driver',
+                             'opflexagent.test.test_fw_wrapper.FakeFw3',
+                             group='SECURITYGROUP')
+
+    def _initialize_agent(self):
+        self._initialize_agent_config()
+
+        class MockFixedIntervalLoopingCall(object):
+            def __init__(self, f):
+                self.f = f
+
+            def start(self, interval=0):
+                self.f()
+
+        with contextlib.nested(
+            mock.patch('opflexagent.utils.ep_managers.endpoint_file_manager'
+                       '.EndpointFileManager'),
+            mock.patch('opflexagent.opflex_notify.OpflexNotifyAgent',
+                       return_value=mock.Mock()),
+            mock.patch('opflexagent.utils.bridge_managers.ovs_manager.'
+                       'OvsManager.setup_integration_bridge',
+                       return_value=mock.Mock()),
+            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                       'create'),
+            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                       'set_secure_mode'),
+            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                       'get_local_port_mac',
+                       return_value='00:00:00:00:00:01'),
+            mock.patch('neutron.agent.linux.utils.get_interface_mac',
+                       return_value='00:00:00:00:00:01'),
+            mock.patch('neutron.agent.common.ovs_lib.BaseOVS.get_bridges'),
+            mock.patch('oslo_service.loopingcall.FixedIntervalLoopingCall',
+                       new=MockFixedIntervalLoopingCall),
+            mock.patch('opflexagent.gbp_ovs_agent.GBPOpflexAgent.'
+                       '_report_state')):
+                kwargs = gbp_ovs_agent.create_agent_config_map(cfg.CONF)
+                agent = gbp_ovs_agent.GBPOpflexAgent(**kwargs)
+            # set back to true because initial report state will succeed due
+            # to mocked out RPC calls
+        agent.use_call = True
+        agent.tun_br = mock.Mock()
+        agent.ep_manager = mock.Mock()
+        agent.bridge_manager = mock.Mock()
+        agent.of_rpc.get_gbp_details = mock.Mock()
+        agent.notify_worker.terminate()
+        return agent
+
+
+class TestFirewallWrapper(TestFirewallWrapperBase):
+    """Test basic firewall wrapper functionality
+
+       This tests the basic firewall wrapper functions.
+       It does not test the decorators of the mocked
+       classes.
+    """
+    def setUp(self):
+        self.fw1 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw1').start()()
+        self.fw2 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw2').start()()
+        self.fw3 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw3').start()()
+
+        self.strategy_fn = mock.patch(
+            'opflexagent.gbp_ovs_agent.strategy_fn').start()
+        super(TestFirewallWrapper, self).setUp()
+
+    def test_fw_wrapper_normal_strategy_key1(self):
+        """Test non-decorator-based strategy methods
+
+           Test the firewall wrapper class' strategy
+           methods that use port-based keying. This
+           verifies the first key in the map.
+        """
+        self.strategy_fn.return_value = 'dvs_port_key'
+        self.agent.sg_agent.firewall.prepare_port_filter(port1)
+        self.fw1.prepare_port_filter.assert_called_once_with(port1)
+        self.fw2.prepare_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.apply_port_filter(port1)
+        self.fw1.apply_port_filter.assert_called_once_with(port1)
+        self.fw2.apply_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.update_port_filter(port1)
+        self.fw1.update_port_filter.assert_called_once_with(port1)
+        self.fw2.update_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.remove_port_filter(port1)
+        self.fw1.remove_port_filter.assert_called_once_with(port1)
+        self.fw2.remove_port_filter.assert_not_called()
+
+        self.agent.sg_agent.firewall.update_security_group_rules(
+            sg_id1, sg_rule1)
+        self.fw1.update_security_group_rules.assert_called_once_with(
+            sg_id1, sg_rule1)
+        self.fw2.update_security_group_rules.assert_called_once_with(
+            sg_id1, sg_rule1)
+        self.agent.sg_agent.firewall.update_security_group_members(
+            sg_id1, sg_members1)
+        self.fw1.update_security_group_members.assert_called_once_with(
+            sg_id1, sg_members1)
+        self.fw2.update_security_group_members.assert_called_once_with(
+            sg_id1, sg_members1)
+        self.agent.sg_agent.firewall.filter_defer_apply_on()
+        self.fw1.filter_defer_apply_on.assert_called_once_with()
+        self.fw2.filter_defer_apply_on.assert_called_once_with()
+        self.agent.sg_agent.firewall.filter_defer_apply_off()
+        self.fw1.filter_defer_apply_off.assert_called_once_with()
+        self.fw2.filter_defer_apply_off.assert_called_once_with()
+
+    def test_fw_wrapper_normal_strategy_key2(self):
+        """Test non-decorator-based strategy methods
+
+           Test the firewall wrapper class' strategy
+           methods that use port-based keying. This
+           verifies the second key in the map.
+        """
+        self.strategy_fn.return_value = 'foo_key'
+        self.agent.sg_agent.firewall.prepare_port_filter(port2)
+        self.fw2.prepare_port_filter.assert_called_once_with(port2)
+        self.fw1.prepare_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.apply_port_filter(port2)
+        self.fw2.apply_port_filter.assert_called_once_with(port2)
+        self.fw1.apply_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.update_port_filter(port2)
+        self.fw2.update_port_filter.assert_called_once_with(port2)
+        self.fw1.update_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.remove_port_filter(port2)
+        self.fw2.remove_port_filter.assert_called_once_with(port2)
+        self.fw1.remove_port_filter.assert_not_called()
+
+        self.agent.sg_agent.firewall.update_security_group_rules(
+            sg_id1, sg_rule1)
+        self.fw2.update_security_group_rules.assert_called_once_with(
+            sg_id1, sg_rule1)
+        self.fw1.update_security_group_rules.assert_called_once_with(
+            sg_id1, sg_rule1)
+        self.agent.sg_agent.firewall.update_security_group_members(
+            sg_id1, sg_members1)
+        self.fw2.update_security_group_members.assert_called_once_with(
+            sg_id1, sg_members1)
+        self.fw1.update_security_group_members.assert_called_once_with(
+            sg_id1, sg_members1)
+        self.agent.sg_agent.firewall.filter_defer_apply_on()
+        self.fw2.filter_defer_apply_on.assert_called_once_with()
+        self.fw1.filter_defer_apply_on.assert_called_once_with()
+        self.agent.sg_agent.firewall.filter_defer_apply_off()
+        self.fw2.filter_defer_apply_off.assert_called_once_with()
+        self.fw1.filter_defer_apply_off.assert_called_once_with()
+
+
+class TestFirewallWrapperDefault(TestFirewallWrapperBase):
+    """Test default firewall wrapper functionality
+
+       This tests the default firewall wrapper functions.
+       It does not test the decorators of the mocked
+       classes.
+    """
+    def setUp(self):
+        self.fw1 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw1').start()()
+        self.fw2 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw2').start()()
+        self.fw3 = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw3').start()()
+
+        self.strategy_fn = mock.patch(
+            'opflexagent.gbp_ovs_agent.strategy_fn').start()
+        super(TestFirewallWrapperDefault, self).setUp()
+
+    def _initialize_agent_config(self):
+        cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+        cfg.CONF.set_override('firewall_map', [], 'OPFLEX')
+        cfg.CONF.set_default('firewall_driver',
+                             'opflexagent.test.test_fw_wrapper.FakeFw3',
+                             group='SECURITYGROUP')
+
+    def test_fw_wrapper_default_strategy(self):
+        """Test non-decorator-based strategy methods
+
+           Test the firewall wrapper class' strategy
+           methods that use port-based keying. This
+           verifies the second key in the map.
+        """
+        self.strategy_fn.return_value = None
+        self.agent.sg_agent.firewall.prepare_port_filter(port2)
+        self.fw3.prepare_port_filter.assert_called_once_with(port2)
+        self.fw1.prepare_port_filter.assert_not_called()
+        self.fw2.prepare_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.apply_port_filter(port2)
+        self.fw3.apply_port_filter.assert_called_once_with(port2)
+        self.fw1.apply_port_filter.assert_not_called()
+        self.fw2.apply_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.update_port_filter(port2)
+        self.fw3.update_port_filter.assert_called_once_with(port2)
+        self.fw1.update_port_filter.assert_not_called()
+        self.fw2.update_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.remove_port_filter(port2)
+        self.fw3.remove_port_filter.assert_called_once_with(port2)
+        self.fw1.remove_port_filter.assert_not_called()
+        self.fw2.remove_port_filter.assert_not_called()
+        self.agent.sg_agent.firewall.update_security_group_rules(
+            sg_id1, sg_rule1)
+        self.fw3.update_security_group_rules.assert_called_once_with(
+            sg_id1, sg_rule1)
+        self.fw1.update_security_group_rules.assert_not_called()
+        self.fw2.update_security_group_rules.assert_not_called()
+        self.agent.sg_agent.firewall.update_security_group_members(
+            sg_id1, sg_members1)
+        self.fw3.update_security_group_members.assert_called_once_with(
+            sg_id1, sg_members1)
+        self.fw1.update_security_group_members.not_called()
+        self.fw2.update_security_group_members.not_called()
+        self.agent.sg_agent.firewall.filter_defer_apply_on()
+        self.fw3.filter_defer_apply_on.assert_called_once_with()
+        self.fw1.filter_defer_apply_on.assert_not_called()
+        self.fw2.filter_defer_apply_on.assert_not_called()
+        self.agent.sg_agent.firewall.filter_defer_apply_off()
+        self.fw3.filter_defer_apply_off.assert_called_once_with()
+        self.fw1.filter_defer_apply_off.assert_not_called()
+        self.fw2.filter_defer_apply_off.assert_not_called()
+
+
+class TestFirewallWrapperDecorators(TestFirewallWrapperBase):
+
+    def setUp(self):
+        self.fw1ports = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw1.ports').start()()
+        self.fw1defer = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw1.defer_apply').start()()
+        self.fw2ports = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw2.ports').start()()
+        self.fw2defer = mock.patch(
+            'opflexagent.test.test_fw_wrapper.FakeFw2.defer_apply').start()()
+
+        self.strategy_fn = mock.patch(
+            'opflexagent.gbp_ovs_agent.strategy_fn').start()
+        super(TestFirewallWrapperDecorators, self).setUp()
+
+    #TODO(tbachman) Figure out how to properly test decorators
+    def _test_fw_wrapper_decorator_strategy_key1(self):
+        self.strategy_fn.return_value = None
+        self.agent.sg_agent.firewall.ports
+        self.fw1ports.assert_called_once_with()
+        self.fw2ports.assert_called_once_with()
+
+        self.agent.sg_agent.firewall.defer_apply()
+        self.fw1defer.assert_called_once_with()
+        self.fw2defer.assert_called_once_with()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -18,6 +18,7 @@ sys.modules["apicapi"] = mock.Mock()
 sys.modules["pyinotify"] = mock.Mock()
 
 import contextlib
+from opflexagent import constants as ofcst
 from opflexagent import gbp_ovs_agent
 from opflexagent import snat_iptables_manager
 from opflexagent.test import base
@@ -320,3 +321,14 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             self.agent.process_deleted_ports(port_info)
             # Nothing to do
             self.assertFalse(self.agent.ep_manager.undeclare_endpoint.called)
+
+
+class TestGBPOpflexAgentDvs(TestGBPOpflexAgent):
+
+    def setUp(self):
+        cfg.CONF.set_override('hypervisor_type',
+                              ofcst.HYPERVISOR_VCENTER, 'OPFLEX')
+        super(TestGBPOpflexAgentDvs, self).setUp()
+
+    def test_hypervisor_type_dvs(self):
+        self.assertTrue(self.agent.hypervisor_type == ofcst.HYPERVISOR_VCENTER)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -670,3 +670,16 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             os.remove(file_format % port_id)
         except OSError as e:
             LOG.debug(e.message)
+
+
+class EndpointFileManagerDvs(EndpointFileManager):
+    """ File Based endpoint manager for DVS
+
+    File based interface between the GBP Opflex agent and the opflex OVS
+    agent. This version won't create endpoints if the port owner is
+    compute:nova, since those EPs can't be managed by our agent when
+    using a VMware DVS.
+    """
+    def declare_endpoint(self, port, mapping):
+        if port.device_owner != 'compute:nova':
+            super(EndpointFileManagerDvs, self).declare_endpoint(port, mapping)

--- a/opflexagent/utils/fw_drivers/dvs.py
+++ b/opflexagent/utils/fw_drivers/dvs.py
@@ -1,0 +1,60 @@
+# Copyright 2015 Mirantis, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.agent import firewall
+from oslo_log import log as logging
+
+#from vmware_dvs.common import config
+#from vmware_dvs.utils import security_group_utils as sg_util
+#from vmware_dvs.utils import dvs_util
+
+LOG = logging.getLogger(__name__)
+
+#CONF = config.CONF
+
+
+class DVSFirewallDriver(firewall.FirewallDriver):
+    """DVS Firewall Driver.
+    """
+    def __init__(self):
+        pass
+
+    def prepare_port_filter(self, port):
+        LOG.info(_("Applied security group rules for port %s"), port['id'])
+
+    def apply_port_filter(self, port):
+        pass
+
+    def update_port_filter(self, port):
+        LOG.info(_("Updated security group rules for port %s"), port['id'])
+
+    def remove_port_filter(self, port):
+        pass
+
+    @property
+    def ports(self):
+        return self.dvs_ports
+
+    def update_security_group_rules(self, sg_id, sg_rules):
+        LOG.debug("Update rules of security group (%s)", sg_id)
+
+    def update_security_group_members(self, sg_id, sg_members):
+        LOG.debug("Update members of security group (%s)", sg_id)
+
+    def filter_defer_apply_on(self):
+        pass
+
+    def filter_defer_apply_off(self):
+        pass


### PR DESCRIPTION
This adds a derived agent that provides a new parameter
to the plugin, hypervisor_type, which can be used by the
mechanism driver to indicate the appropriate VIF type to
nova when peroforming port binding. It also adds a specialized
Endpoint manager and Firewall driver, in order to support
multiple firewall implementations, and prevent creation of
EP files for ports owned by compute:nova on hosts that are
running nova-compute for vCenter.

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>