### PR TITLE
introduce MTU configuration for dhcp advertisement

### DIFF
--- a/opflexagent/test/test_type_opflex.py
+++ b/opflexagent/test/test_type_opflex.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2014 Thales Services SAS
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.plugins.ml2 import config
+from neutron.tests.unit import testlib_api
+
+from opflexagent import config as ofconf  # noqa
+from opflexagent import type_opflex
+
+
+OPFLEX_NETWORKS = ['opflex_net1', 'opflex_net2']
+
+
+class FlatTypeTest(testlib_api.SqlTestCase):
+
+    def setUp(self):
+        super(FlatTypeTest, self).setUp()
+        config.cfg.CONF.set_override('opflex_networks', OPFLEX_NETWORKS,
+                                     group='OPFLEX')
+        self.driver = type_opflex.OpflexTypeDriver()
+        self.driver.physnet_mtus = []
+
+    def test_get_mtu(self):
+        config.cfg.CONF.set_override('segment_mtu', 1475, group='ml2')
+        config.cfg.CONF.set_override('path_mtu', 1400, group='ml2')
+        self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
+        self.assertEqual(1450, self.driver.get_mtu('physnet1'))
+
+        config.cfg.CONF.set_override('segment_mtu', 1375, group='ml2')
+        config.cfg.CONF.set_override('path_mtu', 1400, group='ml2')
+        self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
+        self.assertEqual(1375, self.driver.get_mtu('physnet1'))
+
+        config.cfg.CONF.set_override('segment_mtu', 0, group='ml2')
+        config.cfg.CONF.set_override('path_mtu', 1425, group='ml2')
+        self.driver.physnet_mtus = {'physnet1': 1450, 'physnet2': 1400}
+        self.assertEqual(1400, self.driver.get_mtu('physnet2'))
+
+        config.cfg.CONF.set_override('segment_mtu', 0, group='ml2')
+        config.cfg.CONF.set_override('path_mtu', 0, group='ml2')
+        self.driver.physnet_mtus = {}
+        self.assertEqual(0, self.driver.get_mtu('physnet1'))

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -283,7 +283,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         else:
             if (mapping.get('enable_dhcp_optimization', False) and
                'subnets' in mapping):
-                    self._map_dhcp_info(fixed_ips, mapping['subnets'],
+                    self._map_dhcp_info(fixed_ips, mapping,
                                         mapping_dict)
         ips_aap = []
         for aap in mapping.get('allowed_address_pairs', []):
@@ -353,8 +353,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 nh.next_hop_iface = None
                 LOG.info(_("Add/update SNAT info: %s"), nh)
 
-    def _map_dhcp_info(self, fixed_ips, subnets, mapping_dict):
+    def _map_dhcp_info(self, fixed_ips, mapping, mapping_dict):
         """ Add DHCP specific info to the EP file."""
+        subnets = mapping['subnets']
         v4subnets = {k['id']: k for k in subnets
                      if k['ip_version'] == 4 and k['enable_dhcp']}
         v6subnets = {k['id']: k for k in subnets
@@ -379,11 +380,16 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                      'next-hop': hr['nexthop']})
             if 'dhcp_server_ips' in sn and sn['dhcp_server_ips']:
                 dhcp4['server-ip'] = sn['dhcp_server_ips'][0]
+            if 'interface_mtu' in mapping:
+                dhcp4['interface-mtu'] = mapping['interface_mtu']
             mapping_dict['dhcp4'] = dhcp4
             break
         if len(v6subnets) > 0 and v6subnets[0]['dns_nameservers']:
             mapping_dict['dhcp6'] = {
                 'dns-servers': v6subnets[0]['dns_nameservers']}
+            if 'interface_mtu' in mapping:
+                mapping_dict['dhcp6']['interface-mtu'] = mapping[
+                    'interface_mtu']
 
     def _load_es_next_hop_info(self, es_cfg):
         def parse_range(val):


### PR DESCRIPTION
The RCP endpoint will provide interface_mtu value in the port
mapping, that can be used by opflex to advertise the right MTU size
via DHCP.

Partially-Close: https://github.com/noironetworks/support/issues/73 