### PR TITLE
Allow SNAT EP to be created in different EPG

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -444,10 +444,15 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     not ipm.get('nat_epg_name')):
                 continue
             es = ipm['external_segment_name']
-            epg = (ipm.get('nat_epg_app_profile',
-                           gbp_details['app_profile_name']) + "|" +
-                   ipm['nat_epg_name'])
+            nat_app_prof = ipm.get('nat_epg_app_profile',
+                                   gbp_details['app_profile_name'])
+            epg = nat_app_prof + "|" + ipm['nat_epg_name']
             ipm['nat_epg_name'] = epg
+            if ipm.get('next_hop_ep_epg'):
+                nh_epg = (ipm.get('next_hop_ep_app_profile', nat_app_prof) +
+                          "|" + ipm['next_hop_ep_epg'])
+                ipm['next_hop_ep_epg'] = nh_epg
+
             next_hop_if, next_hop_mac = self._get_next_hop_info_for_es(ipm)
             if not next_hop_if or not next_hop_mac:
                 continue
@@ -634,8 +639,10 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     ipm["nat_epg_name"]
                 )
             },
-            "policy-space-name": ipm['nat_epg_tenant'],
-            "endpoint-group-name": ipm['nat_epg_name'],
+            "policy-space-name": (ipm.get('next_hop_ep_tenant') or
+                                  ipm['nat_epg_tenant']),
+            "endpoint-group-name": (ipm.get('next_hop_ep_epg') or
+                                    ipm['nat_epg_name']),
             "interface-name": nh.next_hop_iface,
             "ip": [str(x) for x in ips],
             "mac": nh.next_hop_mac,


### PR DESCRIPTION
The SNAT EP is always created in the
NAT EPG. By allowing a different EPG, we can
decouple the NAT EPG (that contains floating-IP
endpoints) from SNAT endpoints; this allows us
to do per-tenant NAT EPG.

Signed-off-by: Amit Bose <amitbose@gmail.com>