### PR TITLE
Transiction refactored agent to asynchronous model

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -36,7 +36,15 @@ gbp_opts = [
     cfg.ListOpt('internal_floating_ip6_pool',
                default=['fe80::/64'],
                help=_("IPv6 pool used for intermediate floating-IPs "
-                      "with SNAT"))
+                      "with SNAT")),
+    cfg.IntOpt('endpoint_request_timeout', default=10,
+               help=_("Value in seconds that defines after how long the agent "
+                      "should reschedule port info on missing response.")),
+    cfg.IntOpt('config_apply_interval', default=0.5,
+               help=_("Value in seconds (fraction of a second is allowed as "
+                      "well) that defines how often the agent checks for RPC "
+                      "responses and applies them if any were received while "
+                      "in idle.")),
 ]
 
 cfg.CONF.register_opts(gbp_opts, "OPFLEX")

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -32,7 +32,6 @@ from neutron.plugins.ml2.drivers.openvswitch.agent import (
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from oslo_config import cfg
 from oslo_log import log as logging
-import oslo_messaging
 from oslo_service import loopingcall
 
 from opflexagent import as_metadata_manager
@@ -42,17 +41,14 @@ from opflexagent import opflex_notify
 from opflexagent import rpc
 from opflexagent.utils.bridge_managers import ovs_manager
 from opflexagent.utils.ep_managers import endpoint_file_manager as ep_manager
+from opflexagent.utils.port_managers import async_port_manager as port_manager
 
 eventlet_utils.monkey_patch()
 LOG = logging.getLogger(__name__)
 
 
-class GBPOvsPluginApi(rpc.GBPServerRpcApiMixin):
-    pass
-
-
 class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
-                     rpc.GbpNeutronAgentRpcCallbackMixin):
+                     rpc.OpenstackRpcMixin):
     """Group Based Policy Opflex Agent.
 
     The GBP opflex agent assumes a pre-existing bridge (integration bridge is
@@ -62,8 +58,6 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
     The GBP Opflex Agent
     """
-
-    target = oslo_messaging.Target(version='1.2')
 
     def __init__(self, root_helper=None, **kwargs):
         self.opflex_networks = kwargs['opflex_networks']
@@ -94,6 +88,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         self.setup_rpc()
         self.local_ip = kwargs['local_ip']
         self.polling_interval = kwargs['polling_interval']
+        self.config_apply_interval = kwargs['config_apply_interval']
         self.minimize_polling = kwargs['minimize_polling']
         self.ovsdb_monitor_respawn_interval = (kwargs.get(
             'ovsdb_monitor_respawn_interval') or
@@ -109,9 +104,11 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
         self.quitting_rpc_timeout = kwargs['quitting_rpc_timeout']
         # Initialize the Endpoint Manager.
-        # TODO(ivar): make this component pluggable.
+        # TODO(ivar): make these components pluggable.
         self.ep_manager = ep_manager.EndpointFileManager().initialize(
             self.host, self.bridge_manager, kwargs)
+        self.port_manager = port_manager.AsyncPortManager().initialize(
+            self.host, self, kwargs)
 
     def setup_report(self):
         report_interval = cfg.CONF.AGENT.report_interval
@@ -140,7 +137,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         self.agent_id = 'opflex-agent-%s' % cfg.CONF.host
         self.context = context.get_admin_context_without_session()
         # Set GBP rpc API
-        self.of_rpc = GBPOvsPluginApi(rpc.TOPIC_OPFLEX)
+        self.of_rpc = rpc.GBPServerRpcApi(rpc.TOPIC_OPFLEX)
         self.plugin_rpc = ovs.OVSPluginApi(topics.PLUGIN)
         self.sg_plugin_rpc = sg_rpc.SecurityGroupServerRpcApi(topics.PLUGIN)
         self.sg_agent = sg_rpc.SecurityGroupAgentRpc(
@@ -152,7 +149,8 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         consumers = [[topics.PORT, topics.UPDATE],
                      [topics.PORT, topics.DELETE],
                      [topics.SECURITY_GROUP, topics.UPDATE],
-                     [topics.SUBNET, topics.UPDATE]]
+                     [topics.SUBNET, topics.UPDATE],
+                     [rpc.TOPIC_OPFLEX, rpc.VRF, topics.UPDATE]]
         self.connection = agent_rpc.create_consumers(
             self.endpoints, self.topic, consumers, start_listening=False)
 
@@ -170,7 +168,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 port_info.get('vrf_updated'))
 
     def port_bound(self, port, net_uuid, network_type, physical_network,
-                   fixed_ips, device_owner, ovs_restarted):
+                   fixed_ips, device_owner):
         # TODO(ivar): No flows are needed in OVS, and GBP details can now
         # be retrieved in a sane way. This methos probably is not needed
         # anymore
@@ -218,14 +216,6 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
     def process_network_ports(self, port_info, ovs_restarted):
         resync_a = False
         resync_b = False
-        # TODO(salv-orlando): consider a solution for ensuring notifications
-        # are processed exactly in the same order in which they were
-        # received. This is tricky because there are two notification
-        # sources: the neutron server, and the ovs db monitor process
-        # If there is an exception while processing security groups ports
-        # will not be wired anyway, and a resync will be triggered
-        # TODO(salv-orlando): Optimize avoiding applying filters unnecessarily
-        # (eg: when there are no IP address changes)
         self.sg_agent.setup_port_filters(port_info.get('added', set()),
                                          port_info.get('updated', set()))
         # VIF wiring needs to be performed always for 'new' devices.
@@ -238,8 +228,10 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         if devices_added_updated:
             start = time.time()
             try:
-                skipped_devices = self.treat_devices_added_or_updated(
-                    devices_added_updated, ovs_restarted)
+                # Schedule request for port update
+                self.port_manager.schedule_update(devices_added_updated)
+                # Apply configuration
+                skipped_devices = self.port_manager.apply_config()
                 LOG.debug("process_network_ports - iteration:%(iter_num)d - "
                           "treat_devices_added_or_updated completed. "
                           "Skipped %(num_skipped)d devices of "
@@ -274,6 +266,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
     def treat_devices_removed(self, devices):
         resync = False
+        self.port_manager.unschedule_update(devices)
         self.sg_agent.remove_devices_filter(devices)
         for device in devices:
             LOG.info(_LI("Attachment %s removed"), device)
@@ -291,7 +284,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         return resync
 
     def process_vrf_update(self, vrf_update):
-        # TODO(ivar): use the acync model
+        # TODO(ivar): use the async model
         vrf_details_list = self.of_rpc.get_vrf_details_list(
             self.context, self.agent_id, vrf_update, self.host)
         for details in vrf_details_list:
@@ -299,78 +292,61 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             # the right method once the redesign is complete.
             self.ep_manager.vrf_info_to_file(details)
 
-    def treat_devices_added_or_updated(self, devices, ovs_restarted):
-        # TODO(ivar): Move this method in the ep manager
-
-        skipped_devices = []
-        try:
-            devices_details_list = self.plugin_rpc.get_devices_details_list(
-                self.context,
-                devices,
-                self.agent_id,
-                cfg.CONF.host)
-            devices_gbp_details_list = self.of_rpc.get_gbp_details_list(
-                self.context, self.agent_id, devices, cfg.CONF.host)
-            # Correlate port details
-            gbp_details_per_device = {x['device']: x for x in
-                                      devices_gbp_details_list if x}
-        except Exception as e:
-            raise ovs.DeviceListRetrievalError(devices=devices, error=e)
-        for details in devices_details_list:
-            device = details['device']
-            LOG.debug("Processing port: %s", device)
-            # REVISIT(ivar): this is not a public facing API, we will move to
-            # the right method once the redesign is complete.
-            port = self.bridge_manager.int_br.get_vif_port_by_id(device)
-            if not port:
-                # The port disappeared and cannot be processed
-                LOG.info(_("Port %s was not found on the integration bridge "
-                           "and will therefore not be processed"), device)
-                skipped_devices.append(device)
-                # Delete EP file
-                self.ep_manager.undeclare_endpoint(device)
-                continue
-
-            gbp_details = gbp_details_per_device.get(details['device'], {})
+    def treat_devices_added_or_updated(self, details):
+        """Process added or updated devices
+        :param: Port details retrieved from the Neutron server
+        :returns: Boolean indicating whether the device was processed or
+                  skipped
+        """
+        device = details['device']
+        LOG.debug("Processing port: %s", device)
+        # REVISIT(ivar): this is not a public facing API, we will move to
+        # the right method once the redesign is complete.
+        port = self.bridge_manager.int_br.get_vif_port_by_id(device)
+        if port:
+            gbp_details = details.get('gbp_details')
+            neutron_details = details.get('neutron_details')
             if gbp_details and 'port_id' not in gbp_details:
                 # The port is dead
                 details.pop('port_id', None)
-            if 'port_id' in details:
+            if neutron_details and 'port_id' in neutron_details:
                 LOG.info(_("Port %(device)s updated. Details: %(details)s"),
                          {'device': device, 'details': details})
                 # Inject GBP details
                 port.gbp_details = gbp_details
-                self.treat_vif_port(port, details['port_id'],
-                                    details['network_id'],
-                                    details['network_type'],
-                                    details['physical_network'],
-                                    details['admin_state_up'],
-                                    details['fixed_ips'],
-                                    details['device_owner'],
-                                    ovs_restarted)
+                self.treat_vif_port(port, neutron_details['port_id'],
+                                    neutron_details['network_id'],
+                                    neutron_details['network_type'],
+                                    neutron_details['physical_network'],
+                                    neutron_details['admin_state_up'],
+                                    neutron_details['fixed_ips'],
+                                    neutron_details['device_owner'])
                 # update plugin about port status
-                # FIXME(salv-orlando): Failures while updating device status
-                # must be handled appropriately. Otherwise this might prevent
-                # neutron server from sending network-vif-* events to the nova
-                # API server, thus possibly preventing instance spawn.
-                if details.get('admin_state_up'):
+                if neutron_details.get('admin_state_up'):
                     LOG.debug(_("Setting status for %s to UP"), device)
                     self.plugin_rpc.update_device_up(
-                        self.context, device, self.agent_id, cfg.CONF.host)
+                        self.context, device, self.agent_id, self.host)
                 else:
                     LOG.debug(_("Setting status for %s to DOWN"), device)
                     self.plugin_rpc.update_device_down(
-                        self.context, device, self.agent_id, cfg.CONF.host)
-                LOG.info(_("Configuration for device %s completed."), device)
+                        self.context, device, self.agent_id, self.host)
+                LOG.info(_("Configuration for device %s completed."),
+                         device)
             else:
                 LOG.warn(_("Device %s not defined on plugin"), device)
-                if (port and port.ofport != -1):
+                if port and port.ofport != -1:
                     self.port_dead(port)
-        return skipped_devices
+        else:
+            # The port disappeared and cannot be processed
+            LOG.info(_("Port %s was not found on the integration bridge "
+                       "and will therefore not be processed"), device)
+            self.ep_manager.undeclare_endpoint(device)
+            return False
+        return True
 
     def treat_vif_port(self, vif_port, port_id, network_id, network_type,
                        physical_network, admin_state_up,
-                       fixed_ips, device_owner, ovs_restarted):
+                       fixed_ips, device_owner):
         # When this function is called for a port, the port should have
         # an OVS ofport configured, as only these ports were considered
         # for being treated. If that does not happen, it is a potential
@@ -381,8 +357,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         if vif_port:
             if admin_state_up:
                 self.port_bound(vif_port, network_id, network_type,
-                                physical_network, fixed_ips, device_owner,
-                                ovs_restarted)
+                                physical_network, fixed_ips, device_owner)
             else:
                 self.port_dead(vif_port)
         else:
@@ -397,10 +372,12 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                   {'iter_num': self.iter_num,
                    'port_stats': port_stats,
                    'elapsed': elapsed})
-        if elapsed < self.polling_interval:
-            # TODO(ivar) use this polling time to apply incoming config
-            # and verify timeouts
-            time.sleep(self.polling_interval - elapsed)
+        while elapsed < self.polling_interval:
+            self.port_manager.apply_config()
+            # TODO(ivar): Verify optimal sleep time
+            time.sleep(min(self.config_apply_interval,
+                           self.polling_interval - elapsed))
+            elapsed = time.time() - start_time
         else:
             LOG.debug("Loop iteration exceeded interval "
                       "(%(polling_interval)s vs. %(elapsed)s)!",
@@ -414,6 +391,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         if 'removed' in port_info:
             self.deleted_ports -= port_info['removed']
         deleted_ports = list(self.deleted_ports)
+        self.port_manager.unschedule_update(deleted_ports)
         while self.deleted_ports:
             port_id = self.deleted_ports.pop()
             self.bridge_manager.process_deleted_port(port_id)
@@ -550,6 +528,9 @@ def create_agent_config_map(conf):
     agent_config = ovs.create_agent_config_map(conf)
     agent_config['epg_mapping_dir'] = conf.OPFLEX.epg_mapping_dir
     agent_config['opflex_networks'] = conf.OPFLEX.opflex_networks
+    agent_config['endpoint_request_timeout'] = (
+        conf.OPFLEX.endpoint_request_timeout)
+    agent_config['config_apply_interval'] = conf.OPFLEX.config_apply_interval
     agent_config['internal_floating_ip_pool'] = (
         conf.OPFLEX.internal_floating_ip_pool)
     agent_config['internal_floating_ip6_pool'] = (

--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -37,7 +37,7 @@ class OpflexNotifyAgent(object):
         self.agent_id = 'opflex-notify-agent-%s' % self.host
         self.context = context.get_admin_context_without_session()
         self.sockname = OPFLEX_NOTIFY_SOCKNAME
-        self.of_rpc = opflexagent.gbp_ovs_agent.GBPOvsPluginApi(
+        self.of_rpc = opflexagent.rpc.GBPServerRpcApi(
             opflexagent.rpc.TOPIC_OPFLEX)
 
     def _handle(self, uuids, mac, addr):

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -1,0 +1,208 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sys
+
+import mock
+sys.modules["apicapi"] = mock.Mock()
+sys.modules["pyinotify"] = mock.Mock()
+
+from opflexagent import gbp_ovs_agent
+from opflexagent.utils.port_managers import async_port_manager
+
+from neutron.agent.dhcp import config as dhcp_config
+from neutron.tests import base
+from oslo_config import cfg
+from oslo_utils import uuidutils
+
+_uuid = uuidutils.generate_uuid
+EP_DIR = '.%s_endpoints/'
+
+
+class TestAsyncPortManager(base.BaseTestCase):
+
+    def setUp(self):
+        cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+        super(TestAsyncPortManager, self).setUp()
+        cfg.CONF.set_default('quitting_rpc_timeout', 10, 'AGENT')
+        cfg.CONF.set_default('endpoint_request_timeout', 10000, 'OPFLEX')
+        self.manager = self._initialize_agent()
+        self.agent = self.manager.gbp_agent
+        self.manager.pending_requests_by_request_id = (
+            self.manager.pending_requests._pending_requests_by_request_id)
+        self.manager.pending_requests_by_device_id = (
+            self.manager.pending_requests._pending_requests_by_device_id)
+
+    def _check_call_list(self, expected, observed, check_all=True):
+        for call in expected:
+            self.assertTrue(call in observed,
+                            msg='Call not found, expected:\n%s\nobserved:'
+                                '\n%s' % (str(call), str(observed)))
+            observed.remove(call)
+        if check_all:
+            self.assertFalse(
+                len(observed),
+                msg='There are more calls than expected: %s' % str(observed))
+
+    def _initialize_agent(self):
+        kwargs = gbp_ovs_agent.create_agent_config_map(cfg.CONF)
+        agent = async_port_manager.AsyncPortManager().initialize(
+            'h1', mock.Mock(), kwargs)
+        agent.of_rpc = mock.Mock()
+        return agent
+
+    def _expire_update(self, ports_to_expire):
+        for device in ports_to_expire:
+            # Same reference is in the by_request_id dictionary
+            self.manager.pending_requests_by_device_id[device]['timestamp'] = (
+                -1)
+
+    def _sort_requests(self, requests):
+        return sorted(requests, key=lambda x: x['request_id'])
+
+    def _get_device_requests(self, devices):
+        return [self.manager.pending_requests_by_device_id[x] for x in devices]
+
+    def test_initialized(self):
+        self.assertEqual(10000, self.manager.request_timeout)
+
+    def test_schedule_update(self):
+        # There are no pending nor new requests, nothing happens
+        self.manager.schedule_update()
+        self.assertEqual(
+            0, self.manager.of_rpc.request_endpoint_details_list.call_count)
+
+        # Set new updates
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        self.assertEqual(4, len(self.manager.pending_requests_by_request_id))
+        self.assertEqual(4, len(self.manager.pending_requests_by_device_id))
+        self.assertEqual(
+            to_schedule,
+            set(self.manager.pending_requests_by_device_id.keys()))
+        self.assertEqual(
+            set([x['request_id'] for x in
+                 self.manager.pending_requests_by_device_id.values()]),
+            set(self.manager.pending_requests_by_request_id.keys()))
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self.manager.pending_requests_by_request_id.values())))
+
+        self.manager.of_rpc.reset_mock()
+        # The updates expired
+        self._expire_update(ports_to_expire=set(['1', '3']))
+        # Verify updates are reapplied
+        self.manager.schedule_update(set())
+        # timestamp refreshed and call reissued
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['1']['timestamp'])
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['3']['timestamp'])
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self._get_device_requests(['1', '3']))))
+
+        self.manager.of_rpc.reset_mock()
+        # Verify expired and new ports requests
+        self._expire_update(set(['2', '4']))
+        self.manager.schedule_update(set(['5']))
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['2']['timestamp'])
+        self.assertNotEqual(
+            -1, self.manager.pending_requests_by_device_id['4']['timestamp'])
+        (self.manager.of_rpc.request_endpoint_details_list.
+            assert_called_once_with(
+                self.manager.context, agent_id=self.manager.agent_id,
+                host=self.manager.host,
+                requests=self._sort_requests(
+                    self._get_device_requests(['2', '4', '5']))))
+
+    def test_opflex_update(self):
+        # Set up some requests
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+
+        # Verify answer to some of them
+        update = self._get_device_requests(['1', '3'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        # Still pending until configuration apply happens
+        self.assertTrue(
+            '1' in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '3' in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            update[0]['request_id'] in
+            self.manager.pending_requests_by_request_id)
+        self.assertTrue(
+            update[1]['request_id'] in
+            self.manager.pending_requests_by_request_id)
+        self.assertTrue('1' in self.manager.response_by_device_id)
+        self.assertTrue('3' in self.manager.response_by_device_id)
+
+        # Ignore update
+        update[0]['request_id'] = 'stuff'
+        update[0]['device'] = '5'
+        self.manager._opflex_endpoint_update(mock.Mock(), update[:1])
+        # Update was ignored
+        self.assertTrue('5' not in self.manager.response_by_device_id)
+
+    def test_apply_config(self):
+        self.agent.treat_devices_added_or_updated = mock.Mock(
+            return_value=True)
+
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '2', '4'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        expected_calls = [mock.call(self.manager.response_by_device_id[x])
+                          for x in ['1', '2', '4']]
+        self.manager.apply_config()
+        # Removed from pending requests
+        self.assertTrue(
+            '1' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '2' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(
+            '4' not in self.manager.pending_requests_by_device_id)
+        self._check_call_list(
+            expected_calls,
+            self.agent.treat_devices_added_or_updated.call_args_list)
+        self.assertEqual({}, self.manager.response_by_device_id)
+
+    def test_apply_config_fails(self):
+        self.agent.treat_devices_added_or_updated = mock.Mock(
+            side_effect=Exception)
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '2', '4'])
+        self.manager._opflex_endpoint_update(mock.Mock(), update)
+        self.assertRaises(Exception, self.manager.apply_config)
+        # responses are restored after the exception
+        self.assertEqual(3, len(self.manager.response_by_device_id))
+
+    def test_unschedule_update(self):
+        to_schedule = set(['1', '2', '3', '4'])
+        self.manager.schedule_update(to_schedule)
+        update = self._get_device_requests(['1', '3'])
+        self.manager.unschedule_update(set(['1', '3']))
+        self.assertTrue('1' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue('3' not in self.manager.pending_requests_by_device_id)
+        self.assertTrue(update[0]['request_id'] not in
+                        self.manager.pending_requests_by_request_id)
+        self.assertTrue(update[1]['request_id'] not in
+                        self.manager.pending_requests_by_request_id)

--- a/opflexagent/test/test_rpc.py
+++ b/opflexagent/test/test_rpc.py
@@ -1,0 +1,99 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import sys
+
+import mock
+sys.modules["apicapi"] = mock.Mock()
+sys.modules["pyinotify"] = mock.Mock()
+
+from opflexagent import rpc
+from opflexagent.test import base
+
+
+class TestOpflexRpc(base.OpflexTestBase):
+
+    def setUp(self):
+        super(TestOpflexRpc, self).setUp()
+        self.callback = rpc.GBPServerRpcCallback(mock.Mock(), mock.Mock())
+
+    def test_request_endpoint_details(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details(mock.ANY, host='h1')
+        (self.callback.agent_notifier.opflex_endpoint_update.
+            assert_called_once_with(mock.ANY, [result], host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_endpoint_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details(mock.ANY, host='h1')
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_endpoint_update.called)
+
+    def test_request_vrf_details(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details(mock.ANY, host='h1')
+        (self.callback.agent_notifier.opflex_vrf_update.
+            assert_called_once_with(mock.ANY, [result], host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_vrf_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details(mock.ANY, host='h1')
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_vrf_update.called)
+
+    def test_request_endpoint_details_list(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        (self.callback.agent_notifier.opflex_endpoint_update.
+            assert_called_once_with(mock.ANY, [result] * 3, host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_endpoint_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.callback.request_endpoint_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_endpoint_update.called)
+
+    def test_request_vrf_details_list(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        (self.callback.agent_notifier.opflex_vrf_update.
+            assert_called_once_with(mock.ANY, [result] * 3, host='h1'))
+
+        # Test None return
+        self.callback.agent_notifier.opflex_vrf_update.reset_mock()
+        result = None
+        self.callback.gbp_driver.request_vrf_details = mock.Mock(
+            return_value=result)
+        self.callback.request_vrf_details_list(
+            mock.ANY, host='h1', requests=range(3))
+        self.assertFalse(
+            self.callback.agent_notifier.opflex_vrf_update.called)

--- a/opflexagent/test/test_type_opflex.py
+++ b/opflexagent/test/test_type_opflex.py
@@ -13,8 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from neutron.plugins.ml2 import config
+from neutron.common import config as nconfig  # noqa
+from neutron.plugins.ml2 import config  # noqa
 from neutron.tests.unit import testlib_api
+from oslo_config import cfg
 
 from opflexagent import config as ofconf  # noqa
 from opflexagent import type_opflex
@@ -23,12 +25,12 @@ from opflexagent import type_opflex
 OPFLEX_NETWORKS = ['opflex_net1', 'opflex_net2']
 
 
-class FlatTypeTest(testlib_api.SqlTestCase):
+class OpflexTypeTest(testlib_api.SqlTestCase):
 
     def setUp(self):
-        super(FlatTypeTest, self).setUp()
-        config.cfg.CONF.set_override('opflex_networks', OPFLEX_NETWORKS,
-                                     group='OPFLEX')
+        super(OpflexTypeTest, self).setUp()
+        cfg.CONF.set_override('opflex_networks', OPFLEX_NETWORKS,
+                              group='OPFLEX')
         self.driver = type_opflex.OpflexTypeDriver()
 
     def test_physnet_mtus_initiated(self):

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -1,0 +1,171 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+
+from neutron.agent import rpc as agent_rpc
+from neutron.common import topics
+from neutron import context
+from neutron.i18n import _LE, _LI, _LW  # noqa
+from oslo_log import log as logging
+from oslo_utils import excutils
+from oslo_utils import uuidutils
+
+from opflexagent import rpc
+from opflexagent.utils.port_managers import port_manager_base as base
+
+LOG = logging.getLogger(__name__)
+
+
+class RequestMap(object):
+
+    def __init__(self):
+        self._pending_requests_by_device_id = {}
+        self._pending_requests_by_request_id = {}
+
+    def get_by_device_id(self, device_id):
+        return self._pending_requests_by_device_id.get(device_id)
+
+    def get_by_request_id(self, request_id):
+        return self._pending_requests_by_request_id.get(request_id)
+
+    def get_requests(self):
+        return self._pending_requests_by_request_id.values()
+
+    def update_request(self, request):
+        # Add or replace
+        # Remove current requests if any
+        self.pop_by_device_id(request['device'])
+        # Replace with new requests
+        self._pending_requests_by_device_id[request['device']] = request
+        self._pending_requests_by_request_id[request['request_id']] = request
+
+    def pop_by_request_id(self, request_id):
+        current_request = self._pending_requests_by_request_id.pop(
+            request_id, {})
+        self._pending_requests_by_device_id.pop(
+            current_request.get('device'), None)
+        return current_request or None
+
+    def pop_by_device_id(self, device_id):
+        current_request = self._pending_requests_by_device_id.pop(device_id,
+                                                                  {})
+        self._pending_requests_by_request_id.pop(
+            current_request.get('request_id'), None)
+        return current_request or None
+
+
+class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
+    """ Async Port Manager
+
+    Uses asynchronous RPC APIs to retrieve information from the Neutron server.
+    """
+
+    def initialize(self, host, gbp_agent, config):
+        self.agent_id = gbp_agent.agent_id
+        self.gbp_agent = gbp_agent
+        self._setup_rpc()
+        self.pending_requests = RequestMap()
+        self.response_by_device_id = {}
+        self.request_timeout = config['endpoint_request_timeout']
+        self.host = host
+        return self
+
+    def apply_config(self):
+        skipped = []
+        response_by_device_id_copy = self.response_by_device_id
+        self.response_by_device_id = {}
+        try:
+            for details in response_by_device_id_copy.values():
+                # Context switch might happen here
+                if not self.gbp_agent.treat_devices_added_or_updated(details):
+                    skipped.append(details['device'])
+                # Remove the request after a configuration write without
+                # errors. Leaving the request pending is useful in case of
+                # exceptions raised by the method above, since timeout will
+                # eventually kick in and the port will go to the right state.
+                self.pending_requests.pop_by_request_id(details['request_id'])
+        except Exception as e:
+            LOG.debug("An exception has occurred.")
+            with excutils.save_and_reraise_exception():
+                # The upper layers will trigger the resync
+                LOG.error(_LE("Configuration failed on port manager: %s"),
+                          e.message)
+                # Newer responses take precedence over old ones.
+                response_by_device_id_copy.update(self.response_by_device_id)
+                self.response_by_device_id = response_by_device_id_copy
+        return skipped
+
+    def schedule_update(self, device_ids=None):
+        current_time = int(round(time.time() * 1000))
+        device_ids = set(device_ids or [])
+        LOG.debug('Update initially scheduled for port ids %s', device_ids)
+        # See if more ports need to be updated due to request timeout
+        for request in self.pending_requests.get_requests():
+            if current_time - request['timestamp'] > self.request_timeout:
+                LOG.info(_LI('Request %s has timed out, rescheduling'),
+                         request['request_id'])
+                device_ids.add(request['device'])
+                # Remove from the pending requests, concurrency is not a
+                # concern because of how greenthreads work
+                self.pending_requests.pop_by_request_id(request['request_id'])
+
+        LOG.info(_LI('Update scheduled for port ids %s'), device_ids)
+        requests = []
+        for device_id in device_ids:
+            request = {'request_id': uuidutils.generate_uuid(),
+                       'timestamp': current_time, 'device': device_id}
+            requests.append(request)
+            self.pending_requests.update_request(request)
+
+        LOG.debug('Scheduled requests: %s', requests)
+        if requests:
+            self.of_rpc.request_endpoint_details_list(
+                self.context, agent_id=self.agent_id,
+                requests=sorted(requests, key=lambda x: x['request_id']),
+                host=self.host)
+
+    def unschedule_update(self, device_ids=None):
+        LOG.info(_LI("Unschedule update request for devices %s"), device_ids)
+        for device_id in device_ids:
+            self.pending_requests.pop_by_device_id(device_id)
+
+    def _setup_rpc(self):
+        self.context = context.get_admin_context_without_session()
+        # Set GBP rpc API
+        self.of_rpc = rpc.GBPServerRpcApi(rpc.TOPIC_OPFLEX)
+        self.topic = topics.AGENT
+        self.endpoints = [self]
+        consumers = [[rpc.TOPIC_OPFLEX, rpc.ENDPOINT, topics.UPDATE]]
+        self.connection = agent_rpc.create_consumers(
+            self.endpoints, self.topic, consumers, start_listening=True)
+
+    def _opflex_endpoint_update(self, context, details):
+        # Don't worry about concurrency, greenthreads won't be scheduled until
+        # an explicit IO call is perfomed.
+        LOG.info(_LI('Got endpoint update from the server'))
+        LOG.debug('The following updates were received: %s', details)
+        for detail in details:
+            if 'request_id' in detail:
+                if not self.pending_requests.get_by_request_id(
+                        detail['request_id']):
+                    # This is a old request, ignore.
+                    LOG.debug(
+                        'Ignoring update with request ID %s as it is not '
+                        'in the pending list', detail['request_id'])
+                    continue
+                self.response_by_device_id[detail['device']] = detail
+            LOG.debug("Got response for port %(port_id)s in "
+                      "%(secs)s seconds",
+                      {'port_id': detail.get('device'),
+                       'secs': ((time.time() * 1000) -
+                                float(detail.get('timestamp', 0)))})

--- a/opflexagent/utils/port_managers/port_manager_base.py
+++ b/opflexagent/utils/port_managers/port_manager_base.py
@@ -1,0 +1,62 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class PortManagerBase(object):
+    """ Port Manager base class
+
+    Defines an interface between the GBP opflex Agent and the Neutron server.
+    The port manager takes care of requesting and processing Neutron's ports
+    related info. Uses the gbp_agent for applying ports' configuration.
+    """
+
+    @abc.abstractmethod
+    def initialize(self, host, gbp_agent, config):
+        """ Port Manager initialization method.
+
+        This method will be called before any other.
+
+        :param host: agent host
+        :param gbp_agent: the gbp agent handler.
+        :param config: configuration dictionary
+
+        :returns: self
+        """
+
+    def apply_config(self):
+        """ Apply Port config.
+
+        Applies currently stored configuration to the datapath, using the
+        gbp agent.
+
+        :returns: list of skipper devices
+        """
+
+    def schedule_update(self, port_ids=None):
+        """ Schedule port updates.
+
+        Old unattended requests should be handled here as well
+
+        :param port_ids: ports for which update is needed
+        """
+
+    def unschedule_update(self, port_ids=None):
+        """ Unchedule port updates.
+
+        Used in case of deleted or removed ports
+
+        :param port_ids: ports for which update is not needed anymore
+        """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ oslo.utils!=2.6.0,>=2.0.0 # Apache-2.0
 oslo.i18n>=2.1.0 # Apache-2.0
 oslo.log>=1.8.0 # Apache-2.0
 oslo.config>=2.3.0 # Apache-2.0
-pyinotify
+#pyinotify

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands = {posargs}
 # H405 multi line docstring summary not separated with an empty line
 # H904 Wrap long lines in parentheses instead of a backslash
 # TODO(marun) H404 multi line docstring should start with a summary
-ignore = H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
+ignore = H202,H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
 show-source = true
 builtins = _
 exclude = .venv,.git,.tox,dist,doc,*openstack/common*,*neutron/common*,*lib/python*,*egg,build,tools,.ropeproject,rally-scenarios


### PR DESCRIPTION
- Introduce Port Manager. This module takes care of managing
the async comunication between Neutron and the Opflex Agent
- Switch to the request_* RPC calls.

To avoid increasing the chance of conflicts even further, some
of the methods currently on the main agent class were not moved
to the port manager. This will be done eventually.