### PR TITLE
Add support for launching DVS agent

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -45,6 +45,10 @@ gbp_opts = [
                         "as well) that defines how often the agent checks for "
                         "RPC responses and applies them if any were received "
                         "while in idle.")),
+    cfg.StrOpt('agent_mode',
+               default='opflex',
+               help=_("Set the mode of the agent to be used. Options are: "
+                      "'opflex' (default), 'dvs', and 'dvs_no_binding'.")),
 ]
 
 cfg.CONF.register_opts(gbp_opts, "OPFLEX")

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -10,6 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import importlib
 import signal
 import sys
 import time
@@ -46,6 +47,8 @@ from opflexagent.utils.port_managers import async_port_manager as port_manager
 
 eventlet_utils.monkey_patch()
 LOG = logging.getLogger(__name__)
+
+DVS_AGENT_MODULE = 'vmware_dvs.agent.dvs_neutron_agent'
 
 
 # TODO(bose) Remove when we switch to using RPC method
@@ -577,28 +580,104 @@ def main():
     common_config.setup_logging()
     q_utils.log_opt_values(LOG)
 
-    try:
-        agent_config = create_agent_config_map(cfg.CONF)
-    except ValueError as e:
-        LOG.error(_('%s Agent terminated!'), e)
+    agent_mode = cfg.CONF.OPFLEX.agent_mode
+    if agent_mode == 'dvs':
+        agent = main_dvs()
+    elif agent_mode == 'dvs_no_binding':
+        agent = main_dvs(no_binding=True)
+    else:
+        agent = main_opflex()
+    if not agent:
         sys.exit(1)
 
+    LOG.info(_("Agent initialized successfully, now running... "))
+    agent.daemon_loop()
+
+
+def agent_startup_helper(create_config_map_fn, agent_class, root_helper=None):
     try:
-        agent = GBPOpflexAgent(root_helper=cfg.CONF.AGENT.root_helper,
-                               **agent_config)
+        agent_config = create_config_map_fn(cfg.CONF)
+    except ValueError as e:
+        LOG.error(_("Couldn't create config map (%s), Agent terminated!"), e)
+        return None
+
+    try:
+        if root_helper:
+            agent = agent_class(root_helper, **agent_config)
+        else:
+            agent = agent_class(**agent_config)
+
     except RuntimeError as e:
-        LOG.error(_("%s Agent terminated!"), e)
-        sys.exit(1)
+        LOG.error(_("Couldn't create agent (%s), Agent terminated!"), e)
+        return None
     signal.signal(signal.SIGTERM, agent._handle_sigterm)
+    return agent
+
+
+def main_dvs(no_binding=False):
+    dvs_agent = None
+    try:
+        dvs_agent = importlib.import_module(DVS_AGENT_MODULE)
+    except ValueError as e:
+        LOG.error(_LE(
+            "Couldn't import DVS agent class (%s), Agent terminated!"), e)
+        return None
+
+    def dummy_function(config, pg_cache=False):
+        return {}
+
+    if no_binding:
+        dvs_agent.dvs_util.create_network_map_from_config = dummy_function
+
+    class DVSAgentNoBinding(dvs_agent.DVSAgent):
+
+        # Specialize the RPCs to be No-Ops
+        def create_network(self, context, current, segment):
+            pass
+
+        def delete_network(self, context, current, segment):
+            pass
+
+        def network_delete(self, context, network_id):
+            pass
+
+        def update_network(self, context, current, segment, original):
+            pass
+
+        def bind_port(self, context, current,
+                      network_segments, network_current):
+            pass
+
+        def post_update_port(self, context, current, original, segment):
+            pass
+
+        def delete_port(self, context, current, original, segment):
+            pass
+
+    if no_binding:
+        agent_class = DVSAgentNoBinding
+    else:
+        agent_class = dvs_agent.DVSAgent
+
+    create_config_map_fn = dvs_agent.create_agent_config_map
+    agent = agent_startup_helper(create_config_map_fn, agent_class)
+
+    return agent
+
+
+def main_opflex():
+    agent_class = GBPOpflexAgent
+    root_helper = cfg.CONF.AGENT.root_helper
+    create_config_map_fn = create_agent_config_map
+    agent = agent_startup_helper(create_config_map_fn, agent_class,
+                         root_helper=root_helper)
 
     # Start everything.
     LOG.info(_("Initializing metadata service ... "))
     helper = cfg.CONF.AGENT.root_helper
     metadata_mgr = as_metadata_manager.AsMetadataManager(LOG, helper)
     metadata_mgr.ensure_initialized()
-
-    LOG.info(_("Agent initialized successfully, now running... "))
-    agent.daemon_loop()
+    return agent
 
 
 if __name__ == "__main__":

--- a/opflexagent/test/test_agent_types.py
+++ b/opflexagent/test/test_agent_types.py
@@ -1,0 +1,83 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from opflexagent import gbp_ovs_agent
+from opflexagent.test import base
+
+from oslo_config import cfg
+
+
+class TestGBPOpflexAgentTypes(base.OpflexTestBase):
+
+    def setUp(self):
+        super(TestGBPOpflexAgentTypes, self).setUp()
+        cfg.CONF.set_default('quitting_rpc_timeout', 10, 'AGENT')
+        # UTs will hang when run from tox w/o this
+        self.signal_patch = mock.patch('signal.signal')
+        self.signal_patch.start()
+
+    def tearDown(self):
+        super(TestGBPOpflexAgentTypes, self).tearDown()
+        self.signal_patch.stop()
+
+    def test_opflex_agent_mode(self):
+        opflex_agent = mock.patch('opflexagent.gbp_ovs_agent.GBPOpflexAgent')
+        opflex_patch = opflex_agent.start()
+        metadata_mgr = mock.patch(
+            'opflexagent.as_metadata_manager.AsMetadataManager')
+        metadata_patch = metadata_mgr.start()
+        cfg.CONF.set_override('agent_mode', 'opflex', 'OPFLEX')
+        with mock.patch('sys.argv'):
+            gbp_ovs_agent.main()
+            opflex_patch.assert_called_once()
+            metadata_patch.assert_called_once()
+        opflex_agent.stop()
+        metadata_mgr.stop()
+
+    def test_dvs_agent_mode(self):
+        mock_dvs_instance = mock.MagicMock()
+        import_mock = mock.patch('importlib.import_module',
+                                 return_value=mock_dvs_instance)
+        import_patch = import_mock.start()
+        cfg.CONF.set_override('agent_mode', 'dvs', 'OPFLEX')
+        with mock.patch('sys.argv'):
+            gbp_ovs_agent.main()
+            import_patch.assert_called_once()
+            mock_dvs_instance.create_agent_config_map.assert_called_once()
+        import_mock.stop()
+
+    def test_dvs_agent_no_binding_mode(self):
+        mock_dvs_instance = mock.MagicMock()
+        import_mock = mock.patch('importlib.import_module',
+                                 return_value=mock_dvs_instance)
+        import_patch = import_mock.start()
+        cfg.CONF.set_override('agent_mode', 'dvs_no_binding', 'OPFLEX')
+        with mock.patch('sys.argv'):
+            gbp_ovs_agent.main()
+            import_patch.assert_called_once()
+            mock_dvs_instance.create_agent_config_map.assert_called_once()
+        import_mock.stop()
+
+    def test_dvs_agent_mode_no_package(self):
+        import_mock = mock.patch('importlib.import_module',
+                                 side_effect=ValueError)
+        import_patch = import_mock.start()
+        cfg.CONF.set_override('agent_mode', 'dvs', 'OPFLEX')
+        with mock.patch('sys.argv'), mock.patch('sys.exit') as sys_patch:
+            try:
+                gbp_ovs_agent.main()
+            except AttributeError:
+                sys_patch.assert_called_once()
+            import_patch.assert_called_once()
+        import_mock.stop()


### PR DESCRIPTION
This adds configuration file options to bring the
OpFlex agent up in a DVS agent mode, or a DVS agent
mode that doesn't perform port-binding. This can be
used either for the APIC ML2 workflow or GBP workflow

This closes issue #291

Signed-off-by: Thomas Bachman <tbachman@yahoo.com>