### PR TITLE
Populate segmentation labels in EP file

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -75,7 +75,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
         return port
 
     def test_port_bound(self):
-        mapping = self._get_gbp_details()
+        mapping = self._get_gbp_details(
+            segmentation_labels=['zone = dmz', ' linux '])
         self.manager.snat_iptables.setup_snat_for_es.return_value = tuple(
             ['foo-if', 'foo-mac'])
         port = self._port()
@@ -91,7 +92,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
                    "mac": 'aa:bb:cc:00:11:22',
                    "promiscuous-mode": mapping['promiscuous_mode'],
                    "uuid": port.vif_id + '|aa-bb-cc-00-11-22',
-                   "attributes": {'vm-name': 'somename'},
+                   "attributes": {'vm-name': 'somename', 'zone': 'dmz',
+                                  'linux': ''},
                    "neutron-network": port.net_uuid,
                    "neutron-metadata-optimization": True,
                    "domain-policy-space": 'apic_tenant',

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -309,6 +309,10 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             mapping_dict['domain-name'] = mapping['vrf_name']
         if 'attestation' in mapping:
             mapping_dict['attestation'] = mapping['attestation']
+        if 'segmentation_labels' in mapping:
+            lbls = [x.partition('=') for x in mapping['segmentation_labels']]
+            mapping_dict.setdefault('attributes', {}).update({
+                x[0].strip(): x[2].strip() for x in lbls})
 
         self._handle_host_snat_ip(mapping.get('host_snat_ips', []))
         self._fill_ip_mapping_info(port.vif_id, mac, mapping,


### PR DESCRIPTION
Labels of the form 'key=value' are added to the
EP file in the 'attributes' section as key -> value.
Other labels of the form 'sometext' are added as
sometext -> <empty string>.

Signed-off-by: Amit Bose <amitbose@gmail.com>