### PR TITLE
Add a way to force-recalculate EP files for a specific compute node

### DIFF
--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -81,6 +81,7 @@ class TestGbpOvsAgent(base.BaseTestCase):
 
     def _initialize_agent(self):
         cfg.CONF.set_override('epg_mapping_dir', self.ep_dir, 'OPFLEX')
+        cfg.CONF.set_override('opflex_agent_dir', self.ep_dir, 'OPFLEX')
         kwargs = gbp_ovs_agent.create_agent_config_map(cfg.CONF)
 
         class MockFixedIntervalLoopingCall(object):


### PR DESCRIPTION
How to force-sync: touch a file named force.sync in the opflex_agent_dir
(default: /var/lib/neutron/opflex_agent) and restart the agent.