### PR TITLE
Make opflex notify socket path configurable

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -49,6 +49,9 @@ gbp_opts = [
                default='opflex',
                help=_("Set the mode of the agent to be used. Options are: "
                       "'opflex' (default), 'dvs', and 'dvs_no_binding'.")),
+    cfg.StrOpt('opflex_notify_socket_path',
+               default='/var/run/opflex-agent-ovs-notif.sock',
+               help=_("Path of the Opflex notification socket."))
 ]
 
 cfg.CONF.register_opts(gbp_opts, "OPFLEX")

--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -28,7 +28,6 @@ from oslo_log import log as logging
 
 
 LOG = logging.getLogger(__name__)
-OPFLEX_NOTIFY_SOCKNAME = '/var/run/opflex-agent-ovs-notif.sock'
 
 
 class OpflexNotifyAgent(object):
@@ -36,7 +35,7 @@ class OpflexNotifyAgent(object):
         self.host = cfg.CONF.host
         self.agent_id = 'opflex-notify-agent-%s' % self.host
         self.context = context.get_admin_context_without_session()
-        self.sockname = OPFLEX_NOTIFY_SOCKNAME
+        self.sockname = cfg.CONF.OPFLEX.opflex_notify_socket_path
         self.of_rpc = opflexagent.rpc.GBPServerRpcApi(
             opflexagent.rpc.TOPIC_OPFLEX)
 

--- a/opflexagent/test/test_agent_types.py
+++ b/opflexagent/test/test_agent_types.py
@@ -40,8 +40,8 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
         cfg.CONF.set_override('agent_mode', 'opflex', 'OPFLEX')
         with mock.patch('sys.argv'):
             gbp_ovs_agent.main()
-            opflex_patch.assert_called_once()
-            metadata_patch.assert_called_once()
+            self.assertEqual(1, opflex_patch.call_count)
+            self.assertEqual(1, metadata_patch.call_count)
         opflex_agent.stop()
         metadata_mgr.stop()
 
@@ -53,8 +53,9 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
         cfg.CONF.set_override('agent_mode', 'dvs', 'OPFLEX')
         with mock.patch('sys.argv'):
             gbp_ovs_agent.main()
-            import_patch.assert_called_once()
-            mock_dvs_instance.create_agent_config_map.assert_called_once()
+            self.assertEqual(1, import_patch.call_count)
+            self.assertEqual(
+                1, mock_dvs_instance.create_agent_config_map.call_count)
         import_mock.stop()
 
     def test_dvs_agent_no_binding_mode(self):
@@ -65,8 +66,9 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
         cfg.CONF.set_override('agent_mode', 'dvs_no_binding', 'OPFLEX')
         with mock.patch('sys.argv'):
             gbp_ovs_agent.main()
-            import_patch.assert_called_once()
-            mock_dvs_instance.create_agent_config_map.assert_called_once()
+            self.assertEqual(1, import_patch.call_count)
+            self.assertEqual(
+                1, mock_dvs_instance.create_agent_config_map.call_count)
         import_mock.stop()
 
     def test_dvs_agent_mode_no_package(self):
@@ -78,6 +80,6 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             try:
                 gbp_ovs_agent.main()
             except AttributeError:
-                sys_patch.assert_called_once()
-            import_patch.assert_called_once()
+                self.assertEqual(1, sys_patch.call_count)
+            self.assertEqual(1, import_patch.call_count)
         import_mock.stop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ oslo.utils!=2.6.0,>=2.0.0 # Apache-2.0
 oslo.i18n>=2.1.0 # Apache-2.0
 oslo.log>=1.8.0 # Apache-2.0
 oslo.config>=2.3.0 # Apache-2.0
-#pyinotify
+pyinotify

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 usedevelop = True
-install_command = pip install -U {opts} {packages}
+install_command =
+  pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka} {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
[OPFLEX]
opflex_notify_socket_path = /var/run/opflex-agent-ovs-notif.sock

Closes noironetworks/support#361