### PR TITLE
Newton sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,59 @@
-*.pyc
+*.py[cod]
+.venv
+
+# C extensions
+*.so
+
+# Packages
+*.egg
 *.egg-info
 dist
 build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
 .tox
-.venv
+nosetests.xml
 .testrepository
+subunit.log
+covhtml
+cover
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+doc/build
+
+# pbr generates these
+AUTHORS
+ChangeLog
+
+# Editors
+*~
+.*.swp
+.*sw?
+
+# Pycharm
+.idea

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -15,9 +15,9 @@ import signal
 import sys
 import time
 
+from neutron._i18n import _LE, _LI, _LW
 from neutron.agent.common import config
 from neutron.agent.common import polling
-from neutron.agent.dhcp import config as dhcp_config
 from neutron.agent.linux import ip_lib
 from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as sg_rpc
@@ -27,7 +27,7 @@ from neutron.common import eventlet_utils
 from neutron.common import exceptions
 from neutron.common import topics
 from neutron.common import utils as q_utils
-from neutron.i18n import _LE, _LI, _LW
+from neutron.conf.agent import dhcp as dhcp_config
 from neutron import context
 from neutron.plugins.ml2.drivers.openvswitch.agent import (
     ovs_neutron_agent as ovs)
@@ -574,7 +574,8 @@ def create_agent_config_map(conf):
 
 def main():
     cfg.CONF.register_opts(ip_lib.OPTS)
-    cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+    dhcp_config.register_agent_dhcp_opts(cfg.CONF)
+    cfg.CONF.set_override("ovsdb_interface", "vsctl", group="OVS")
     config.register_root_helper(cfg.CONF)
     common_config.init(sys.argv[1:])
     common_config.setup_logging()

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -19,7 +19,7 @@ sys.modules["pyinotify"] = mock.Mock()
 from opflexagent import gbp_ovs_agent
 from opflexagent.utils.port_managers import async_port_manager
 
-from neutron.agent.dhcp import config as dhcp_config
+from neutron.conf.agent import dhcp as dhcp_config
 from neutron.tests import base
 from oslo_config import cfg
 from oslo_utils import uuidutils

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -23,7 +23,7 @@ from opflexagent import snat_iptables_manager
 from opflexagent.test import base
 from opflexagent.utils.ep_managers import endpoint_file_manager
 
-from neutron.agent.dhcp import config as dhcp_config
+from neutron.conf.agent import dhcp as dhcp_config
 from oslo_config import cfg
 from oslo_utils import uuidutils
 
@@ -34,7 +34,7 @@ EP_DIR = '.%s_endpoints/'
 class TestEndpointFileManager(base.OpflexTestBase):
 
     def setUp(self):
-        cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
+        dhcp_config.register_agent_dhcp_opts(cfg.CONF)
         super(TestEndpointFileManager, self).setUp()
         cfg.CONF.set_default('quitting_rpc_timeout', 10, 'AGENT')
         self.ep_dir = EP_DIR % _uuid()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -23,7 +23,7 @@ from opflexagent import snat_iptables_manager
 from opflexagent.test import base
 from opflexagent.utils.ep_managers import endpoint_file_manager
 
-from neutron.agent.dhcp import config as dhcp_config
+from neutron.conf.agent import dhcp as dhcp_config
 from oslo_config import cfg
 from oslo_utils import uuidutils
 
@@ -37,6 +37,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
     def setUp(self):
         cfg.CONF.register_opts(dhcp_config.DHCP_OPTS)
         super(TestGBPOpflexAgent, self).setUp()
+        cfg.CONF.set_override("ovsdb_interface", "vsctl", group="OVS")
         notifier_p = mock.patch(NOTIFIER)
         notifier_cls = notifier_p.start()
         self.notifier = mock.Mock()

--- a/opflexagent/test/test_ovs_manager.py
+++ b/opflexagent/test/test_ovs_manager.py
@@ -18,7 +18,7 @@ sys.modules["pyinotify"] = mock.Mock()
 
 from opflexagent.utils.bridge_managers import ovs_manager
 
-from neutron.agent.dhcp import config as dhcp_config
+from neutron.conf.agent import dhcp as dhcp_config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron.tests import base
 from oslo_config import cfg

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from neutron.i18n import _LW
+from neutron._i18n import _LW
 from neutron.plugins.common import constants as n_constants
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from oslo_log import log as logging

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -14,8 +14,8 @@ import copy
 import netaddr
 import os
 
+from neutron._i18n import _LI
 from neutron.common import constants as n_constants
-from neutron.i18n import _LI
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 from oslo_utils import uuidutils

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -12,10 +12,10 @@
 
 import time
 
+from neutron._i18n import _LE, _LI, _LW  # noqa
 from neutron.agent import rpc as agent_rpc
 from neutron.common import topics
 from neutron import context
-from neutron.i18n import _LE, _LI, _LW  # noqa
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import uuidutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-oslo.serialization<1.5.0,>=1.4.0 # Apache-2.0
-oslo.utils!=2.6.0,>=2.0.0 # Apache-2.0
+oslo.serialization>=1.10.0 # Apache-2.0
+oslo.utils>=3.16.0 # Apache-2.0
 oslo.i18n>=2.1.0 # Apache-2.0
-oslo.log>=1.8.0 # Apache-2.0
-oslo.config>=2.3.0 # Apache-2.0
+oslo.log>=1.14.0 # Apache-2.0
+oslo.config>=3.14.0 # Apache-2.0
 pyinotify

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,22 +2,23 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-setuptools>=19.2
--e git+https://github.com/openstack/neutron.git@stable/mitaka#egg=neutron
+setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0  # PSF/ZPL
+-e git+https://github.com/openstack/neutron.git@stable/newton#egg=neutron
 hacking<0.11,>=0.10.0
 
-cliff>=1.14.0 # Apache-2.0
-coverage>=3.6
-fixtures>=1.3.1
+cliff!=1.16.0,!=1.17.0,>=1.15.0  # Apache-2.0
+coverage>=3.6 # Apache-2.0
+fixtures>=3.0.0 # Apache-2.0/BSD
 httplib2>=0.7.5
-mock>=1.2
+mock>=2.0 # BSD
 ordereddict
-python-subunit>=0.0.18
-requests-mock>=0.6.0 # Apache-2.0
-sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
-testrepository>=0.0.18
-testtools>=1.4.0
-testscenarios>=0.4
-WebTest>=2.0
+python-subunit>=0.0.18 # Apache-2.0/BSD
+requests-mock>=1.0 # Apache-2.0
+sphinx!=1.3b1,<1.3,>=1.2.1 # BSD
+testrepository>=0.0.18 # Apache-2.0/BSD
+testresources>=0.2.4 # Apache-2.0/BSD
+testtools>=1.4.0 # MIT
+testscenarios>=0.4 # Apache-2.0/BSD
+WebTest>=2.0 # MIT
 oslotest>=1.10.0 # Apache-2.0
-tempest-lib>=0.8.0
+tempest-lib>=0.14.0  # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 usedevelop = True
 install_command =
-  pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/mitaka} {opts} {packages}
+  pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton} {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
The notable change here is to preserve use of 'ovs-vsctl' though
Neutron has switched to using OVSDB native interface by default.

Please refer to the following for more details:
https://github.com/openstack/neutron/blob/stable/newton/releasenotes/notes/ovsdb-native-by-default-38835d6963592396.yaml