### PR TITLE
Batch RPC calls to avoid congestion

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -37,7 +37,7 @@ gbp_opts = [
                default=['fe80::/64'],
                help=_("IPv6 pool used for intermediate floating-IPs "
                       "with SNAT")),
-    cfg.IntOpt('endpoint_request_timeout', default=10,
+    cfg.IntOpt('endpoint_request_timeout', default=30,
                help=_("Value in seconds that defines after how long the agent "
                       "should reschedule port info on missing response.")),
     cfg.FloatOpt('config_apply_interval', default=0.5,

--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -10,6 +10,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from neutron.common import eventlet_utils
+eventlet_utils.monkey_patch()
+
 import importlib
 import signal
 import sys
@@ -23,7 +26,6 @@ from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as sg_rpc
 from neutron.common import config as common_config
 from neutron.common import constants as n_constants
-from neutron.common import eventlet_utils
 from neutron.common import exceptions
 from neutron.common import topics
 from neutron.common import utils as q_utils
@@ -45,7 +47,6 @@ from opflexagent.utils.bridge_managers import ovs_manager
 from opflexagent.utils.ep_managers import endpoint_file_manager as ep_manager
 from opflexagent.utils.port_managers import async_port_manager as port_manager
 
-eventlet_utils.monkey_patch()
 LOG = logging.getLogger(__name__)
 
 DVS_AGENT_MODULE = 'vmware_dvs.agent.dvs_neutron_agent'

--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -199,15 +199,17 @@ class GBPServerRpcCallback(object):
 
     def request_endpoint_details_list(self, context, **kwargs):
         result = []
-        for request in kwargs.pop('requests', []):
+        # TODO(ivar): have it configurable
+        batch_response = 5
+        for i, request in enumerate(kwargs.pop('requests', [])):
             details = self.gbp_driver.request_endpoint_details(
                 context, request=request, **kwargs)
             if details:
                 result.append(details)
-
-        # Notify the agent back once the answer is calculated
-        # Exclude empty answers as an error as occurred and the agent might
-        # want to retry
+            if result and (i + 1) % batch_response == 0:
+                self.agent_notifier.opflex_endpoint_update(
+                    context, result, host=kwargs.get('host'))
+                result = []
         if result:
             self.agent_notifier.opflex_endpoint_update(
                 context, result, host=kwargs.get('host'))

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -132,6 +132,13 @@ class TestAsyncPortManager(base.BaseTestCase):
                 requests=self._sort_requests(
                     self._get_device_requests(['2', '4', '5']))))
 
+        self.manager.of_rpc.reset_mock()
+        # Verify expired and new ports requests
+        to_schedule = set(['1', '2', '3', '4', '5', '6'])
+        self.manager.schedule_update(to_schedule)
+        self.assertEqual(
+            2, self.manager.of_rpc.request_endpoint_details_list.call_count)
+
     def test_opflex_update(self):
         # Set up some requests
         to_schedule = set(['1', '2', '3', '4'])

--- a/opflexagent/test/test_rpc.py
+++ b/opflexagent/test/test_rpc.py
@@ -97,3 +97,14 @@ class TestOpflexRpc(base.OpflexTestBase):
             mock.ANY, host='h1', requests=range(3))
         self.assertFalse(
             self.callback.agent_notifier.opflex_vrf_update.called)
+
+    def test_request_endpoint_details_list_batch(self):
+        result = {'device': 'someid'}
+        self.callback.gbp_driver.request_endpoint_details = mock.Mock(
+            return_value=result)
+        self.assertEqual(
+            0, self.callback.agent_notifier.opflex_endpoint_update.call_count)
+        self.callback.request_endpoint_details_list(
+            mock.ANY, host='h1', requests=range(11))
+        self.assertEqual(
+            3, self.callback.agent_notifier.opflex_endpoint_update.call_count)

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -128,10 +128,15 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
             self.pending_requests.update_request(request)
 
         LOG.debug('Scheduled requests: %s', requests)
-        if requests:
+        # TODO(ivar): have it configurable
+        # Load balance across multiple servers
+        batch_requests = 5
+        while requests:
+            send = requests[:batch_requests]
+            requests = requests[batch_requests:]
             self.of_rpc.request_endpoint_details_list(
                 self.context, agent_id=self.agent_id,
-                requests=sorted(requests, key=lambda x: x['request_id']),
+                requests=sorted(send, key=lambda x: x['request_id']),
                 host=self.host)
 
     def unschedule_update(self, device_ids=None):


### PR DESCRIPTION
When many VMs are created at the same time, the agent might end up
sending one single big request which requires a long time
before being responded. This can lead to response timeout and
eventual failure of the VM creation. To avoid this issue, batch
requests/answers for the enpoint request RPC into small groups.