### PR TITLE
Fix RPC invocations to neutron server

### DIFF
--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -112,8 +112,8 @@ class GBPServerRpcApi(object):
                                  host=None):
         # Request is a tuple with the device_id as first element, and the
         # request ID as second element
-        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
-        cctxt.cast(context, 'request_endpoint_details', agent_id=agent_id,
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION)
+        cctxt.call(context, 'request_endpoint_details', agent_id=agent_id,
                    request=request, host=host)
 
     @log.log_method_call
@@ -121,16 +121,16 @@ class GBPServerRpcApi(object):
                                       host=None):
         # Requests is a list of tuples with the device_id as first element,
         # and the request ID as second element
-        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
-        cctxt.cast(context, 'request_endpoint_details_list',
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION)
+        cctxt.call(context, 'request_endpoint_details_list',
                    agent_id=agent_id, requests=requests, host=host)
 
     @log.log_method_call
     def request_vrf_details(self, context, agent_id, request=None, host=None):
         # Request is a tuple with the vrf_id as first element, and the
         # request ID as second element
-        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
-        cctxt.cast(context, 'request_vrf_details', agent_id=agent_id,
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION)
+        cctxt.call(context, 'request_vrf_details', agent_id=agent_id,
                    request=request, host=host)
 
     @log.log_method_call
@@ -138,15 +138,15 @@ class GBPServerRpcApi(object):
                                  host=None):
         # Requests is a list of tuples with the vrf_id as first element,
         # and the request ID as second element
-        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
-        cctxt.cast(context, 'request_vrf_details_list',
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION)
+        cctxt.call(context, 'request_vrf_details_list',
                    agent_id=agent_id, requests=requests, host=host)
 
     @log.log_method_call
     def ip_address_owner_update(self, context, agent_id, ip_owner_info,
                                 host=None):
-        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION, fanout=True)
-        cctxt.cast(context, 'ip_address_owner_update', agent_id=agent_id,
+        cctxt = self.client.prepare(version=self.GBP_RPC_VERSION)
+        cctxt.call(context, 'ip_address_owner_update', agent_id=agent_id,
                    ip_owner_info=ip_owner_info, host=host)
 
 

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -125,6 +125,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.bridge_manager.int_br.get_vif_port_set = mock.Mock(
             return_value=set())
         agent.of_rpc.get_gbp_details = mock.Mock()
+        agent.port_manager.of_rpc.request_endpoint_details_list = mock.Mock()
         agent.notify_worker.terminate()
 
     def test_port_unbound_snat_cleanup(self):


### PR DESCRIPTION
There are a few RPCs being invoked on the neutron server as AMQP "cast"
but which should be "call" invocations instead. These RPC invocations
need to reach exactly one neutron server when deployment contains
more than one neutron server (in a multi-node configuration) but ends
up going to every neutron server on account of the current "cast"
invocation with fanout set to True. This leads to the get_gbp_details
method on the neutron server side being processed by every neutron server
and subsequently resulting in undesirable effects such as multiple
host SNAT ports being created instead of exactly one for a given host. This
specific incorrect behavior was actually reported by Cisco IT which led to
the investigation and this patch.