### PR TITLE
Fix setup of integration bridge

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -469,7 +469,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 polling_manager.force_polling()
             ovs_status = self.bridge_manager.check_bridge_status()
             if ovs_status == constants.OVS_RESTARTED:
-                self.bridge_manager.setup_integration_br()
+                self.bridge_manager.setup_integration_bridge()
             elif ovs_status == constants.OVS_DEAD:
                 # Agent doesn't apply any operations when ovs is dead, to
                 # prevent unexpected failure or crash. Sleep and continue


### PR DESCRIPTION
Commit f190f781380a0a3212c07e6f3456e80f0fe0e002 renamed the method
"setup_integration_br" to "setup_integration_bridge". The invocation
of this method still uses the old method name, resulting in an
exception.