### PR TITLE
Fix rootwrap

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,3 @@
 etc/gbp-opflex.filters etc/neutron/rootwrap.d
+etc/cisco-apic.filters etc/neutron/rootwrap.d
 debian/neutron-cisco-apic-host-agent.conf /etc/init/

--- a/etc/cisco-apic.filters
+++ b/etc/cisco-apic.filters
@@ -1,0 +1,17 @@
+# neutron-rootwrap command filters for nodes on which neutron is
+# expected to control network
+#
+# This file should be owned by (and only-writeable by) the root user
+
+# format seems to be
+# cmd-name: filter-name, raw-command, user, args
+
+[Filters]
+
+# cisco-apic filters
+lldpctl: CommandFilter, lldpctl, root
+
+# ip_lib filters
+ip: IpFilter, ip, root
+ip_exec: IpNetnsExecFilter, ip, root
+ovsdb-client: CommandFilter, ovsdb-client, root

--- a/rpm/neutron-opflex-agent.spec.in
+++ b/rpm/neutron-opflex-agent.spec.in
@@ -35,6 +35,8 @@ rm -f requirements.txt
 %{__python2} setup.py install -O1 --install-data / --skip-build --root %{buildroot}
 install -p -D -m 600 etc/gbp-opflex.filters \
     %{buildroot}%{_sysconfdir}/neutron/rootwrap.d/gbp-opflex.filters
+install -p -D -m 600 etc/cisco-apic.filters \
+    %{buildroot}%{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 install -p -D -m 0644 rpm/%{opflex_agent} \
     %{buildroot}/%{_unitdir}/%{opflex_agent}
 install -p -D -m 0644 rpm/%{host_agent} \
@@ -95,6 +97,7 @@ usermod -a -G opflexep neutron
 %{_bindir}/neutron-cisco-apic-host-agent
 %{_bindir}/opflex-ns-proxy
 %{_sysconfdir}/neutron/rootwrap.d/gbp-opflex.filters
+%{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 %{_unitdir}/%{opflex_agent}
 %{_unitdir}/%{host_agent}
 


### PR DESCRIPTION
The rootwrap files needed porting after migration of some
of the agents from the apic-ml2-driver.