### PR TITLE
Fix opflex_notify imports

### DIFF
--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -22,7 +22,8 @@ import time
 from neutron.common import config
 from neutron.common import utils
 from neutron import context
-import opflexagent
+from opflexagent import config as ofcfg  # noqa
+from opflexagent import rpc
 from oslo_config import cfg
 from oslo_log import log as logging
 
@@ -36,8 +37,7 @@ class OpflexNotifyAgent(object):
         self.agent_id = 'opflex-notify-agent-%s' % self.host
         self.context = context.get_admin_context_without_session()
         self.sockname = cfg.CONF.OPFLEX.opflex_notify_socket_path
-        self.of_rpc = opflexagent.rpc.GBPServerRpcApi(
-            opflexagent.rpc.TOPIC_OPFLEX)
+        self.of_rpc = rpc.GBPServerRpcApi(rpc.TOPIC_OPFLEX)
 
     def _handle(self, uuids, mac, addr):
         LOG.debug('Handle: endpoint(s): {}, mac: {}, addr: {}'.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0  # PSF/ZPL
--e git+https://github.com/openstack/neutron.git@stable/newton#egg=neutron
+-e git+https://github.com/openstack/neutron.git@newton-eol#egg=neutron
 hacking<0.11,>=0.10.0
 
 cliff!=1.16.0,!=1.17.0,>=1.15.0  # Apache-2.0


### PR DESCRIPTION
The opflex_notify functionality was broken due issues with imports.
This patch fixes the imports, allowing the notify functionality to
work again.

(cherry picked from commit e5ca10f9c46c3428278bf81f55514ffe264d7823)