### PR TITLE
Fix missing import for opflex-state-watcher

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -33,6 +33,8 @@ from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
+from opflexagent import config as oscfg  # noqa
+
 LOG = logging.getLogger(__name__)
 
 gbp_opts = [


### PR DESCRIPTION
A missing import was causing an exception in the
opflex-state-watcher

(cherry picked from commit 1337432a072c57be2af0b857bad900be44f93dcf)