### PR TITLE
Fix log message in ML2 plugin

### DIFF
--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -126,6 +126,7 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
         requests = []
         for device_id in device_ids:
             request = {'request_id': uuidutils.generate_uuid(),
+                       'host': self.host, 'agent_id': self.agent_id,
                        'timestamp': current_time, 'device': device_id}
             requests.append(request)
             self.pending_requests.update_request(request)


### PR DESCRIPTION
A log message in the ML2 plugin is currently showing values as
None for host and agent_id, since they aren't passed in the RPC.
This populates those fields, so that the log message is accurate,
and therefore more useful in debugging.

(cherry picked from commit 69f98bb803b602ed9a8237bc78135180e4b6fc14)
(cherry picked from commit 06b575e3ff68258c2beab906e1da62675cb68257)