### PR TITLE
Only handle bound ports

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -353,7 +353,11 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             if gbp_details and 'port_id' not in gbp_details:
                 # The port is dead
                 details.pop('port_id', None)
-            if neutron_details and 'port_id' in neutron_details:
+            if (gbp_details and gbp_details.get('host') and
+                gbp_details['host'] != self.host):
+                    self.port_unbound(device)
+                    return False
+            elif neutron_details and 'port_id' in neutron_details:
                 LOG.info(_("Port %(device)s updated. Details: %(details)s"),
                          {'device': device, 'details': details})
                 # Inject GBP/Trunk details
@@ -381,6 +385,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 LOG.warn(_("Device %s not defined on plugin"), device)
                 if port and port.ofport != -1:
                     self.port_unbound(port)
+                    return False
         else:
             # The port disappeared and cannot be processed
             LOG.info(_("Port %s was not found on the integration bridge "

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -111,6 +111,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             # to mocked out RPC calls
             agent.use_call = True
             agent.tun_br = mock.Mock()
+            agent.host = 'host1'
         agent.sg_agent = mock.Mock()
         return agent
 
@@ -404,3 +405,46 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             attached_macs={subports[0].port_id: '0', subports[1].port_id: '1'})
         self.agent.bridge_manager.delete_patch_ports.assert_called_with(
             [subports[0].port_id, subports[1].port_id])
+
+    def test_port_bound_to_host(self):
+        mapping = self._get_gbp_details(device='some_device')
+        port_details = {'device': 'some_device',
+                        'admin_state_up': True,
+                        'port_id': mapping['port_id'],
+                        'network_id': 'some-net',
+                        'network_type': 'opflex',
+                        'physical_network': 'phys_net',
+                        'segmentation_id': '',
+                        'fixed_ips': [],
+                        'device_owner': 'some-vm'}
+        self.agent.plugin_rpc.update_device_up = mock.Mock()
+        self.agent.plugin_rpc.update_device_down = mock.Mock()
+        port = mock.Mock(ofport=1, vif_id=mapping['port_id'])
+        self.agent.bridge_manager.int_br.get_vif_port_by_id = mock.Mock(
+            return_value=port)
+        self.agent.ep_manager._mapping_cleanup = mock.Mock()
+        self.agent.ep_manager._mapping_to_file = mock.Mock()
+
+        # first test is with no binding attribute. This is what
+        # happens when port binding is first attempted, in order to
+        # bind the port to a host.
+        mapping['host'] = ''
+        self.agent.treat_devices_added_or_updated(
+            {'device': 'some_device', 'neutron_details': port_details,
+             'gbp_details': mapping, 'port_id': 'port_id'})
+        self.assertTrue(self.agent.ep_manager._mapping_to_file.called)
+        self.agent.ep_manager._mapping_cleanup.assert_called_once_with(
+            port_details['port_id'], cleanup_vrf=False,
+            mac_exceptions=set([mapping['mac_address']]))
+
+        self.agent.ep_manager._mapping_cleanup.reset_mock()
+        self.agent.ep_manager._mapping_to_file.reset_mock()
+
+        # Now try binding with a different host
+        mapping['host'] = 'host2'
+        self.agent.treat_devices_added_or_updated(
+            {'device': 'some_device', 'neutron_details': port_details,
+             'gbp_details': mapping, 'port_id': 'port_id'})
+        self.assertFalse(self.agent.ep_manager._mapping_to_file.called)
+        self.agent.ep_manager._mapping_cleanup.assert_called_once_with(
+            port_details['device'])


### PR DESCRIPTION
The RPC to get devices for the agent doesn't check to see
if the port is bound to the agent/host. This can lead to the
creation of EP files for ports that the agent isn't responsible
for. A check is added to the device's host. If no host is specified,
or if the host matches the host for the agent, then the port is
processed normally. If there is a host, and it doesn't match the
host for the agent, then the port is removed.

(cherry picked from commit c1c5cd2b17a23ef72556f493842bec0932ab6100)
(cherry picked from commit 54c8ddbf48df59715e080a9641a2776d20d9aa58)