### PR TITLE
Only handle bound ports

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -353,7 +353,11 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             if gbp_details and 'port_id' not in gbp_details:
                 # The port is dead
                 details.pop('port_id', None)
-            if neutron_details and 'port_id' in neutron_details:
+            if (gbp_details and gbp_details.get('host') and
+                gbp_details['host'] != self.host):
+                    self.port_unbound(device)
+                    return False
+            elif neutron_details and 'port_id' in neutron_details:
                 LOG.info(_("Port %(device)s updated. Details: %(details)s"),
                          {'device': device, 'details': details})
                 # Inject GBP/Trunk details
@@ -381,6 +385,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 LOG.warn(_("Device %s not defined on plugin"), device)
                 if port and port.ofport != -1:
                     self.port_unbound(port)
+                    return False
         else:
             # The port disappeared and cannot be processed
             LOG.info(_("Port %s was not found on the integration bridge "


### PR DESCRIPTION
The RPC to get devices for the agent doesn't check to see
if the port is bound to the agent/host. This can lead to the
creation of EP files for ports that the agent isn't responsible
for. A check is added to the device's host. If no host is specified,
or if the host matches the host for the agent, then the port is
processed normally. If there is a host, and it doesn't match the
host for the agent, then the port is removed.

(cherry picked from commit c1c5cd2b17a23ef72556f493842bec0932ab6100)
(cherry picked from commit 54c8ddbf48df59715e080a9641a2776d20d9aa58)
(cherry picked from commit d8b42a4f482302e7545fd88524cb50540d40d273)