### PR TITLE
Add missing .ini file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ exclude .gitreview
 include debian/*
 include debian/source/*
 include etc/*
+include etc/neutron/opflex-agent/*
 include rpm/*
 global-exclude *.pyc

--- a/debian/neutron-cisco-apic-host-agent.conf
+++ b/debian/neutron-cisco-apic-host-agent.conf
@@ -15,5 +15,5 @@ end script
 exec start-stop-daemon --start --chuid neutron \
   --exec /usr/bin/neutron-cisco-apic-host-agent -- \
   --config-file=/etc/neutron/neutron.conf \
-  --config-file=/etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini \
+  --config-file=/etc/neutron/opflex-agent/apic_topology_service.ini \
   --log-file=/var/log/neutron/cisco-apic-host-agent.log

--- a/debian/neutron-cisco-apic-host-agent.service
+++ b/debian/neutron-cisco-apic-host-agent.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Neutron Cisco Host Agent
+After=network.target agent-ovs.service
+Wants=agent-ovs.service
+Before=openstack-nova-compute.service
+
+[Service]
+Type=simple
+User=neutron
+ExecStart=/usr/bin/neutron-cisco-apic-host-agent --config-file=/etc/neutron/neutron.conf --config-file=/etc/neutron/opflex-agent/apic_topology_service.ini --log-file=/var/log/neutron/opflex-agent.log
+PrivateTmp=false
+KillMode=process
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/etc/neutron/opflex-agent/apic_topology_service.ini
+++ b/etc/neutron/opflex-agent/apic_topology_service.ini
@@ -1,0 +1,10 @@
+[apic_host_agent]
+# The uplink ports to check for ACI connectivity
+# apic_host_uplink_ports=[]
+
+# Interval between agent poll for topology (in sec)
+# apic_agent_poll_interval=60
+
+# Interval between agent status updates (in sec)
+# apic_agent_report_interval=60
+

--- a/opflexagent/apic_topology.py
+++ b/opflexagent/apic_topology.py
@@ -63,7 +63,7 @@ apic_opts = [
                  help=_('Interval between agent status updates (in sec)')),
 ]
 
-cfg.CONF.register_opts(apic_opts, "ml2_cisco_apic")
+cfg.CONF.register_opts(apic_opts, "apic_host_agent")
 
 
 class ApicTopologyAgent(manager.Manager):
@@ -72,7 +72,7 @@ class ApicTopologyAgent(manager.Manager):
             host = net_utils.get_hostname()
         super(ApicTopologyAgent, self).__init__(host=host)
 
-        self.conf = cfg.CONF.ml2_cisco_apic
+        self.conf = cfg.CONF.apic_host_agent
         self.count_current = 0
         self.count_force_send = AGENT_FORCE_UPDATE_COUNT
         self.interfaces = {}
@@ -113,7 +113,7 @@ class ApicTopologyAgent(manager.Manager):
         LOG.info("APIC host agent: started on %s", self.host)
 
     @periodic_task.periodic_task(
-        spacing=cfg.CONF.ml2_cisco_apic.apic_agent_poll_interval,
+        spacing=cfg.CONF.apic_host_agent.apic_agent_poll_interval,
         run_immediately=True)
     def _check_for_new_peers(self, context):
         LOG.debug("APIC host agent: _check_for_new_peers")
@@ -274,8 +274,8 @@ def launch(binary, manager, topic=None):
     cfg.CONF(project='neutron')
     common_cfg.init(sys.argv[1:])
     config.setup_logging()
-    report_period = cfg.CONF.ml2_cisco_apic.apic_agent_report_interval
-    poll_period = cfg.CONF.ml2_cisco_apic.apic_agent_poll_interval
+    report_period = cfg.CONF.apic_host_agent.apic_agent_report_interval
+    poll_period = cfg.CONF.apic_host_agent.apic_agent_poll_interval
     server = service.Service.create(
         binary=binary, manager=manager, topic=topic,
         report_interval=report_period, periodic_interval=poll_period)

--- a/opflexagent/test/test_cisco_apic_topology_agent.py
+++ b/opflexagent/test/test_cisco_apic_topology_agent.py
@@ -65,7 +65,7 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase):
             super(TestCiscoApicTopologyAgent, self).setUp()
             # Configure the Cisco APIC mechanism driver
             cfg.CONF.set_override('apic_host_uplink_ports',
-                                  APIC_UPLINK_PORTS, 'ml2_cisco_apic')
+                                  APIC_UPLINK_PORTS, 'apic_host_agent')
             # Patch device_exists
             self.dev_exists = mock.patch(DEV_EXISTS).start()
             # Patch IPDevice

--- a/rpm/neutron-cisco-apic-host-agent.service
+++ b/rpm/neutron-cisco-apic-host-agent.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 User=neutron
-ExecStart=/usr/bin/neutron-cisco-apic-host-agent --config-file=/etc/neutron/neutron.conf --config-file=/usr/share/neutron/neutron-dist.conf --config-file=/etc/neutron/plugins/ml2/ml2_conf_cisco_apic.ini --config-dir=/etc/neutron/conf.d/common --log-file=/var/log/neutron/cisco-apic-host-agent.log
+ExecStart=/usr/bin/neutron-cisco-apic-host-agent --config-file=/etc/neutron/neutron.conf --config-file=/usr/share/neutron/neutron-dist.conf --config-file=/etc/neutron/opflex-agent/apic_topology_service.ini --config-dir=/etc/neutron/conf.d/common --log-file=/var/log/neutron/cisco-apic-host-agent.log
 PrivateTmp=false
 KillMode=process
 Restart=always

--- a/rpm/neutron-opflex-agent.spec.in
+++ b/rpm/neutron-opflex-agent.spec.in
@@ -100,6 +100,7 @@ usermod -a -G opflexep neutron
 %{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 %{_unitdir}/%{opflex_agent}
 %{_unitdir}/%{host_agent}
+%config(noreplace) %{_sysconfdir}/neutron/opflex-agent/apic_topology_service.ini
 
 %changelog
 * Tue Sep 07 2017 Thomas Bachman <bachman@noironetworks.com> - 5.0.1-1

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,7 @@ setuptools.setup(
         'neutron.ml2.type_drivers': [
             'opflex = opflexagent.type_opflex:OpflexTypeDriver',
         ]
-    }
+    },
+    data_files=[('etc/neutron/opflex-agent',
+        ['etc/neutron/opflex-agent/apic_topology_service.ini'])]
 )


### PR DESCRIPTION
The ml2_conf_cisco_apic.ini file was missed during its
port from the apic-ml2-driver package.

(cherry picked from commit cf6bb3062071d61c19bc8e760875517c6ce2c0c6)