### PR TITLE
Add DHCP mac to EP file

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -422,6 +422,14 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                      'next-hop': hr['nexthop']})
             if 'dhcp_server_ips' in sn and sn['dhcp_server_ips']:
                 dhcp4['server-ip'] = sn['dhcp_server_ips'][0]
+            if 'dhcp_server_ports' in sn and sn['dhcp_server_ports']:
+                # REVISIT: The agent currenlty only supports a single
+                # IP, so just use the first IP from the first entry in
+                # the dict. Once the agent supports additional IPs, we
+                # can provide the full dict.
+                dhcp_mac = sn['dhcp_server_ports'].keys()[0]
+                dhcp4['server-mac'] = dhcp_mac
+                dhcp4['server-ip'] = sn['dhcp_server_ports'][dhcp_mac][0]
             if 'interface_mtu' in mapping:
                 dhcp4['interface-mtu'] = mapping['interface_mtu']
             if 'dhcp_lease_time' in mapping:


### PR DESCRIPTION
When using optimized DHCP, the virtual DHCP server needs to
know the MAC as well as the IP address of the server that
it's virtualizing or proxying.