### PR TITLE
Implement force send on topology agent RPC

### DIFF
--- a/opflexagent/host_agent_rpc.py
+++ b/opflexagent/host_agent_rpc.py
@@ -23,17 +23,18 @@ TOPIC_APIC_SERVICE = 'apic-service'
 class ApicTopologyServiceNotifierApi(object):
 
     def __init__(self):
-        target = oslo_messaging.Target(topic=TOPIC_APIC_SERVICE, version='1.2')
+        target = oslo_messaging.Target(topic=TOPIC_APIC_SERVICE, version='2')
         self.client = rpc.get_client(target)
 
     def update_link(self, context, host, interface, mac, switch, module, port,
-                    pod_id, port_description=''):
-        cctxt = self.client.prepare(version='1.2', fanout=False)
+                    pod_id, port_description='', force=False):
+        cctxt = self.client.prepare(version='2', fanout=False)
         cctxt.cast(context, 'update_link', host=host, interface=interface,
                    mac=mac, switch=switch, module=module, port=port,
-                   pod_id=pod_id, port_description=port_description)
+                   pod_id=pod_id, port_description=port_description,
+                   force=force)
 
     def delete_link(self, context, host, interface):
-        cctxt = self.client.prepare(version='1.2', fanout=False)
+        cctxt = self.client.prepare(version='2', fanout=False)
         cctxt.cast(context, 'delete_link', host=host, interface=interface,
                    mac=None, switch=0, module=0, port=0)

--- a/opflexagent/test/test_cisco_apic_topology_agent.py
+++ b/opflexagent/test/test_cisco_apic_topology_agent.py
@@ -120,7 +120,7 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase):
                 self.assertEqual(expected,
                                  self.agent.peers[SERVICE_HOST_IFACE])
                 self.agent.service_agent.update_link.assert_called_once_with(
-                    context, *expected)
+                    context, *expected, force=False)
 
         def test_check_for_new_peers_with_peers(self):
             expected = (SERVICE_HOST, SERVICE_HOST_IFACE,
@@ -135,4 +135,4 @@ class TestCiscoApicTopologyAgent(base.BaseTestCase):
                                    return_value=peers):
                 self.agent._check_for_new_peers(context)
                 self.agent.service_agent.update_link.assert_called_with(
-                    context, *expected)
+                    context, *expected, force=False)


### PR DESCRIPTION
Although we already had a force_send count in place, adding
an explicit force keyword and making this count less aggressive would
work better with the corresponding server side change.