### PR TITLE
Avoid accidental deletion of SNAT EP file

### DIFF
--- a/opflexagent/gbp_ovs_agent.py
+++ b/opflexagent/gbp_ovs_agent.py
@@ -276,6 +276,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                       "treat_devices_removed completed in %(elapsed).3f",
                       {'iter_num': self.iter_num,
                        'elapsed': time.time() - start})
+        stale_eps = [ep for ep in self.ep_manager.get_stale_endpoints()]
+        if stale_eps:
+            self.treat_devices_removed(stale_eps)
         if port_info.get('vrf_updated'):
             self.process_vrf_update(port_info['vrf_updated'])
         # If one of the above operations fails => resync with plugin

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -222,6 +222,14 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                                             '1.1.1.0/24',
                                             '169.254.0.0/16'])})
 
+    def test_stale_endpoints_in_process_network_ports(self):
+        self.agent.ep_manager.undeclare_endpoint = mock.Mock()
+        self.agent.plugin_rpc.update_device_down = mock.Mock()
+        self.agent.ep_manager._stale_endpoints.add('EXT-2.ep')
+        self.agent.process_network_ports({}, False)
+        self.agent.ep_manager.undeclare_endpoint.assert_called_once_with(
+            'EXT-2.ep')
+
     def test_dead_port(self):
         port = mock.Mock(ofport=1)
         self.agent.bridge_manager.int_br.get_vif_port_by_id = mock.Mock(

--- a/opflexagent/utils/ep_managers/endpoint_manager_base.py
+++ b/opflexagent/utils/ep_managers/endpoint_manager_base.py
@@ -69,3 +69,10 @@ class EndpointManagerBase(object):
         :return: set of port IDs for each endpoint registered in the EP
         directory
         """
+
+    @abc.abstractmethod
+    def get_stale_endpoints(self):
+        """ Get stale endpoints that are not tracked by registered endpoints.
+
+        :return: set of stale endpoint IDs
+        """


### PR DESCRIPTION
On a fresh start, the agent was relying on the clean-up
of registered endpoints to remove stale SNAT EP files
(i.e. the files that don't have a cooresponding network
namespace). This can cause accidental removal of SNAT
EP file because the files to be removed are calculated
before updates for ports is processed.
Stale SNAT EP files are now tracked separately from
registered endpoints and cleaned up only when they are
not being used.

Signed-off-by: Amit Bose <amitbose@gmail.com>