### PR TITLE
Make topological calls synchronous

### DIFF
--- a/opflexagent/apic_topology.py
+++ b/opflexagent/apic_topology.py
@@ -43,7 +43,7 @@ ACI_PORT_LOCAL_FORMAT = 'Eth(\d+)/(\d+(\/\d+)*)'
 ACI_VPCPORT_DESCR_FORMAT = ('topology/pod-(\d+)/protpaths-(\d+)-(\d+)/pathep-'
                             '\[(.*)\]')
 
-AGENT_FORCE_UPDATE_COUNT = 30
+AGENT_FORCE_UPDATE_COUNT = 5
 BINARY_APIC_HOST_AGENT = 'neutron-cisco-apic-host-agent'
 TYPE_APIC_HOST_AGENT = 'cisco-apic-host-agent'
 VPCMODULE_NAME = 'vpc-%s-%s'
@@ -165,6 +165,8 @@ class ApicTopologyAgent(manager.Manager):
 
         except Exception:
             LOG.exception("APIC service agent: exception in LLDP parsing")
+            # Force update
+            self.count_current = float('inf')
 
     def _get_peers(self):
         interfaces = {}

--- a/opflexagent/host_agent_rpc.py
+++ b/opflexagent/host_agent_rpc.py
@@ -21,20 +21,23 @@ TOPIC_APIC_SERVICE = 'apic-service'
 
 
 class ApicTopologyServiceNotifierApi(object):
+    # version: 3.0: calls
 
     def __init__(self):
-        target = oslo_messaging.Target(topic=TOPIC_APIC_SERVICE, version='2.0')
+        target = oslo_messaging.Target(topic=TOPIC_APIC_SERVICE, version='3.0')
         self.client = rpc.get_client(target)
 
     def update_link(self, context, host, interface, mac, switch, module, port,
                     pod_id, port_description='', force=False):
-        cctxt = self.client.prepare(version='2.0', fanout=False)
-        cctxt.cast(context, 'update_link', host=host, interface=interface,
-                   mac=mac, switch=switch, module=module, port=port,
-                   pod_id=pod_id, port_description=port_description,
-                   force=force)
+        cctxt = self.client.prepare(version='3.0')
+        return cctxt.call(context, 'update_link', host=host,
+                          interface=interface,
+                          mac=mac, switch=switch, module=module, port=port,
+                          pod_id=pod_id, port_description=port_description,
+                          force=force)
 
     def delete_link(self, context, host, interface):
-        cctxt = self.client.prepare(version='2.0', fanout=False)
-        cctxt.cast(context, 'delete_link', host=host, interface=interface,
-                   mac=None, switch=0, module=0, port=0)
+        cctxt = self.client.prepare(version='3.0')
+        return cctxt.call(context, 'delete_link', host=host,
+                          interface=interface,
+                          mac=None, switch=0, module=0, port=0)


### PR DESCRIPTION
We need a mechanism to know whether the server was able to update
the host link table. Since such operations are usually quick unless
a host interface has moved somewhere, using blocking calls
will give the agent a way to know whether a link update should be
retried.