### PR TITLE
Change EP request timeout

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -37,7 +37,7 @@ gbp_opts = [
                default=['fe80::/64'],
                help=_("IPv6 pool used for intermediate floating-IPs "
                       "with SNAT")),
-    cfg.IntOpt('endpoint_request_timeout', default=10,
+    cfg.IntOpt('endpoint_request_timeout', default=300,
                help=_("Value in seconds that defines after how long the agent "
                       "should reschedule port info on missing response.")),
     cfg.FloatOpt('config_apply_interval', default=0.5,


### PR DESCRIPTION
The current endpoint request timeout value results in
overly-aggressive behavior by the agents when the controller
is under moderate to high loads. This patch increases the
default value for this timeout from 10 seconds to 5 minutes.