### PR TITLE
Add fake agent for load testing

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -57,6 +57,10 @@ gbp_opts = [
     cfg.StrOpt('fabric_bridge', default='br-fabric',
                help=_("The name of the bridge which connects to the ACI "
                       "fabric")),
+    cfg.StrOpt('bridge_manager',
+               default='ovs',
+               help=_("The class to use for OVS bridge management. "
+                      "Options are: 'ovs' (default), and 'fake'.")),
 ]
 
 cfg.CONF.register_opts(gbp_opts, "OPFLEX")

--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -147,6 +147,12 @@ class OpflexNotifyAgent(object):
     def run(self):
         """Infinite loop which catches all exception, exits on ^C"""
 
+        # Don't bother running if we don't have a socket
+        if not self.sockname:
+            LOG.warning("Notification socket not set, "
+                        "notifications will not be sent")
+            return
+
         while True:
             try:
                 client = self._connect()

--- a/opflexagent/utils/bridge_managers/bridge_manager_base.py
+++ b/opflexagent/utils/bridge_managers/bridge_manager_base.py
@@ -14,6 +14,9 @@ import abc
 import six
 
 
+BRIDGE_MANAGER_NAMESPACE = 'opflexagent.utils.bridge_managers'
+
+
 @six.add_metaclass(abc.ABCMeta)
 class BridgeManagerBase(object):
     """ Bridge Manager base class

--- a/opflexagent/utils/bridge_managers/ovs_lib.py
+++ b/opflexagent/utils/bridge_managers/ovs_lib.py
@@ -47,3 +47,9 @@ class OVSBridge(ovs_lib.OVSBridge):
                     yield txn
                 finally:
                     self._transaction = None
+
+
+class FakeOVSBridge(OVSBridge):
+
+    def get_vif_port_by_id(self, port_id):
+        return ovs_lib.VifPort(port_id, None, port_id, None, self)

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -141,3 +141,27 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
 
     def port_dead(self, port, log_errors=True):
         pass
+
+
+class FakeManager(OvsManager):
+    """ Fake Bridge Manager for OpenVSwitch."""
+
+    def initialize(self, host, ovs_config, opflex_conf):
+        self.int_br_device_count = 0
+        self.int_br = ovs_lib.FakeOVSBridge(ovs_config.integration_bridge)
+        self.fabric_br = ovs_lib.FakeOVSBridge(opflex_conf.fabric_bridge)
+        self.setup_integration_bridge()
+        return self
+
+    def scan_ports(self, registered_ports, updated_ports=None):
+        cur_ports = registered_ports
+        for port in updated_ports:
+            if port not in cur_ports:
+                cur_ports.add(port)
+        self.int_br_device_count = len(cur_ports)
+        port_info = {'current': cur_ports}
+        updated_ports = updated_ports or set()
+        if updated_ports:
+            port_info['updated'] = updated_ports
+
+        return port_info

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,10 @@ setuptools.setup(
         ],
         'neutron.ml2.type_drivers': [
             'opflex = opflexagent.type_opflex:OpflexTypeDriver',
+        ],
+        'opflexagent.utils.bridge_managers': [
+            'ovs = opflexagent.utils.bridge_managers.ovs_manager:OvsManager',
+            'fake = opflexagent.utils.bridge_managers.ovs_manager:FakeManager',
         ]
     },
     data_files=[('etc/neutron/opflex-agent',


### PR DESCRIPTION
This adds a version of the bridge manager that can be used
for load testing. The FakeManager class strictly uses the
update and delete port notifications to generate, update,
and delete EP files. It behaves as the current agent, using
RPCs to get GBP details from the plugin. Because it doesn't
depend on ports being added or removed from an OVS bridge,
it can be used with the FakeDriver in Nova to create
virtual hypervisors, so that laod testing for the network
pieces can be performed, without needing the resources
for compute (storage, CPUs, etc.).

(cherry picked from commit 8515cca0007af08f4c29284a4a2a09bb28941f4d)
(cherry picked from commit 236ac19eccd5fbfaaaca0e44cc93905a83af8df6)