### PR TITLE
Fix entry point

### DIFF
--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -14,6 +14,7 @@ from neutron._i18n import _LW
 from neutron.plugins.common import constants as n_constants
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib.utils import helpers
+from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import ovs_lib
 from opflexagent.utils.bridge_managers import trunk_skeleton
@@ -44,6 +45,7 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         self.fabric_br = ovs_lib.OVSBridge(conf.OPFLEX.fabric_bridge)
         self.local_ip = ovs_config.local_ip
         self.setup_integration_bridge()
+        agent_state['agent_type'] = ofcst.AGENT_TYPE_OPFLEX_OVS
         agent_state['bridge_mappings'] = bridge_mappings
         agent_state['datapath_type'] = ovs_config.datapath_type
         agent_state['vhostuser_socket_dir'] = ovs_config.vhostuser_socket_dir

--- a/opflexagent/utils/bridge_managers/vpp_manager.py
+++ b/opflexagent/utils/bridge_managers/vpp_manager.py
@@ -13,6 +13,7 @@
 from neutron.agent.linux import ip_lib
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib import constants as lib_constants
+from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import trunk_skeleton
 from opflexagent.vpplib.VPPApi import VPPApi
@@ -33,6 +34,7 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
     def initialize(self, host, conf, agent_state):
         self.int_br_device_count = 0
         vpp_config = conf.VPP
+        agent_state['agent_type'] = ofcst.AGENT_TYPE_OPFLEX_VPP
         agent_state['vhostuser_socket_dir'] = vpp_config.vhostuser_socket_dir
         return self, agent_state
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'neutron-opflex-agent = '
-                'opflexagent.gbp_ovs_agent:main',
+                'opflexagent.gbp_agent:main',
             'opflex-ep-watcher = '
                 'opflexagent.as_metadata_manager:ep_watcher_main',
             'opflex-state-watcher = '


### PR DESCRIPTION
Commit f811b830bc38be43e566ab34d5c38a2266c1fe0f changed
the module name, but not the entry point. This fixes the
entry point. It also changes the reported agent_type, depending
on the bridge_manager configuration variable.

(cherry picked from commit 23cd823b2885e6c70f9a5a1d182472894fc33fd4)
(cherry picked from commit fc1fb12e3161fd0749f1a16a4afb8fe25d93a1f5)