### PR TITLE
Use only EP filename to forget stale endpoints

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -59,7 +59,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
         return agent
 
     def _mock_agent(self, agent):
-        agent._write_endpoint_file = mock.Mock()
+        agent._write_endpoint_file = mock.Mock(
+            return_value=agent.epg_mapping_file)
         agent._write_vrf_file = mock.Mock()
         agent._delete_endpoint_file = mock.Mock()
         agent._delete_vrf_file = mock.Mock()
@@ -640,7 +641,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
                 exclude_es=['EXT-2'])
 
             self._mock_agent(manager)
-            manager._write_endpoint_file.return_value = 'EXT-1.ep'
+            manager._write_endpoint_file.return_value = (
+                manager.epg_mapping_file % "EXT-1")
 
             # declare a port that uses EXT-1
             port = self._port()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -115,7 +115,8 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
 
     def _mock_agent(self, agent):
         # Mock EP manager methods
-        agent.ep_manager._write_endpoint_file = mock.Mock()
+        agent.ep_manager._write_endpoint_file = mock.Mock(
+            return_value=agent.ep_manager.epg_mapping_file)
         agent.ep_manager._write_vrf_file = mock.Mock()
         agent.ep_manager._delete_endpoint_file = mock.Mock()
         agent.ep_manager._delete_vrf_file = mock.Mock()

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -112,7 +112,8 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
 
     def _mock_agent(self, agent):
         # Mock EP manager methods
-        agent.ep_manager._write_endpoint_file = mock.Mock()
+        agent.ep_manager._write_endpoint_file = mock.Mock(
+            return_value=agent.ep_manager.epg_mapping_file)
         agent.ep_manager._write_vrf_file = mock.Mock()
         agent.ep_manager._delete_endpoint_file = mock.Mock()
         agent.ep_manager._delete_vrf_file = mock.Mock()

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -750,7 +750,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         }
         epfile = self._write_endpoint_file(nh.es_name, ep_dict)
         # SNAT EP is no longer stale
-        self._stale_endpoints.discard(epfile)
+        self._stale_endpoints.discard(os.path.basename(epfile))
 
     def _write_endpoint_file(self, port_id, mapping_dict):
         return self._write_file(port_id, mapping_dict, self.epg_mapping_file)


### PR DESCRIPTION
The EP file name that we get from _write_file()
uses the complete path-name of the file, whereas
the stale endpoints (found during start-up) are
tracked using their file-names only.

Signed-off-by: Amit Bose <amitbose@gmail.com>