### PR TITLE
Support for nested domain details

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -57,6 +57,12 @@ gbp_opts = [
     cfg.StrOpt('fabric_bridge', default='br-fabric',
                help=_("The name of the bridge which connects to the ACI "
                       "fabric")),
+    cfg.StrOpt('nested_domain_uplink_interface', default='patch-fabric-ex',
+               help=_("This is used in the nested Kubernetes configuration "
+                      "to denote the name of the OVS interface that serves "
+                      "as the uplink for the host. On RHEL installation, "
+                      "this corresponds to the patch port on br-fabric that "
+                      "connects to br-ex")),
     cfg.StrOpt('bridge_manager',
                default='ovs',
                help=_("The class to use for OVS bridge management. "

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -635,6 +635,8 @@ def create_agent_config_map(conf):
     except cfg.NoSuchOptError:
         agent_config['dhcp_domain'] = conf.dns_domain
     agent_config['nat_mtu_size'] = conf.OPFLEX.nat_mtu_size
+    agent_config['nested_domain_uplink_interface'] = (
+            conf.OPFLEX.nested_domain_uplink_interface)
     return agent_config
 
 


### PR DESCRIPTION
Provides support for adding lbiface files corresponding
to a Neutron endpoint when the nested domain
VLAN details with are present in the get_gbp_details RPC.

The lbiface files have the following details:
1. uuid (agent assigned, and is unique in the system)
2. interface name
3. VLANs to trunk

E.g.

{
    "uuid": "e4ac02d1-9555-4a37-a09a-236aaf622651",
    "interface-name": "qpicab3d8b8-a3",
    "trunk-vlans": [{"start": 4093}, {"start": 1000, "end": 1001}]
}

Two lbiface files are created for each Neutron endpoint (whenever
the nested domain is configured for the Neutron network),

1. With the interface name corresponding to the Neutron
endpoint (same as which goes into the endpoint file).

2. With the interface name of the uplink interface and the
VLANs detail same as that in (1).

As soon as the agent-ovs sees these lbiface files, its going to
add the necessary flows to trunk the range of VLANs specified
in the "trunk-vlans" section. This should have the effect
of allowing tagged traffic with those VLAN coming from the OpenStack
VMs to go through to the intended destination.

These lbiface files are deleted any time that the corresponding
endpoint file is deleted.

(cherry picked from commit 8ac7761b222b3c6601404e5bf30f9df637c2d75d)
(cherry picked from commit a9c2ee3516e6f72802f3a457b50f434a24a90555)