### PR TITLE
No security groups for EP carrying nested k8s traffic

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -333,7 +333,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'kubernetes', 'type': 'nested-kubernetes'},
                    'trunk-vlans': [{'start': 2, 'end': 4},
                        {'start': 1000, 'end': 1001},
-                       {'start': 4093, 'end': 4093}]}
+                       {'start': 4093}]}
         uplink_lbiface_file = {
                    "interface-name": 'patch-fabric-ex',
                    "uuid": mock.ANY,
@@ -341,13 +341,35 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'kubernetes', 'type': 'nested-kubernetes'},
                    'trunk-vlans': [{'start': 2, 'end': 4},
                        {'start': 1000, 'end': 1001},
-                       {'start': 4093, 'end': 4093}]}
+                       {'start': 4093}]}
         self.manager._write_endpoint_file.assert_called_once_with(
                 ep_name, ep_file)
         calls = [call(ep_name, lbiface_file),
                  call(ep_name + '_uplink', uplink_lbiface_file)]
         self.assertEqual(2, self.manager._write_lbiface_file.call_count)
         self.manager._write_lbiface_file.assert_has_calls(calls)
+
+    def test_list_to_ranges(self):
+        li = [1, 2, 3, 3000, 4093]
+        exp_rng = [{'start': 1, 'end': 3},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [1, 2, 3, 3000, 0, 4093, 3000]
+        exp_rng = [{'start': 1, 'end': 3},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [1, 2, 3000, 0, -2, 4093, 4094, 5000, 3000]
+        exp_rng = [{'start': 1, 'end': 2},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [3000, 1, 4093]
+        exp_rng = [{'start': 1},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
 
     def test_port_multiple_ep_files(self):
         # Prepare AAP list

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -414,11 +414,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         if 'nested_host_vlan' in mapping and mapping['nested_host_vlan']:
             mapping_dict['access-interface-vlan'] = mapping['nested_host_vlan']
         if allowed_vlans:
-            vlan_ranges = self._list_to_range(allowed_vlans)
-            rngs_dict = []
-            for rng in vlan_ranges:
-                rngs_dict.append({'start': rng[0], 'end': rng[-1]})
-            nested_domain_dict['trunk-vlans'] = rngs_dict
+            nested_domain_dict['trunk-vlans'] = self._list_to_range(
+                    allowed_vlans)
         if 'trunk-vlans' in nested_domain_dict and (
                 nested_domain_dict['trunk-vlans']):
             # First write the lbiface file for the VM's interface
@@ -447,6 +444,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 self._write_lbiface_file(
                         lbiface_file_name + '_' + NESTED_DOMAIN_UPLINK,
                         nested_domain_dict)
+            # REVISIT: Do not configure SG for VMs hosting nested k8s
+            mapping_dict.pop('security-group', None)
 
         # Create one file per MAC address.
         LOG.debug("Final endpoint file for port %(port)s: \n %(mapping)s" %
@@ -460,21 +459,31 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
     def _list_to_range(self, vlans_list):
         vlans_list = list(set(vlans_list))
+        vlans_list = filter(lambda a: a > 0 and a < 4094, vlans_list)
         vlans_list.sort()
-        length = len(vlans_list)
+        vlan_ranges = []
         while vlans_list:
             if len(vlans_list) == 1:
-                yield range(vlans_list[0], vlans_list[0] + 1)
+                vlan_ranges.append({'start': vlans_list[0]})
+                vlans_list.remove(vlans_list[0])
                 break
 
-            step = vlans_list[1] - vlans_list[0]
-            i = next(i for i in range(1, length) if i + 1 == length or (
-                vlans_list[i + 1] - vlans_list[i] != step))
+            start = vlans_list[0]
+            end = start
+            vlans_list.remove(vlans_list[0])
+            while vlans_list:
+                if (vlans_list[0] - end) == 1:
+                    end = vlans_list[0]
+                    vlans_list.remove(vlans_list[0])
+                else:
+                    break
 
-            yield range(vlans_list[0], vlans_list[i] + 1, step)
+            if end and end != start:
+                vlan_ranges.append({'start': start, 'end': end})
+            else:
+                vlan_ranges.append({'start': start})
 
-            vlans_list = vlans_list[i + 1:]
-            length -= i + 1
+        return vlan_ranges
 
     def _handle_host_snat_ip(self, host_snat_ips):
         for hsi in host_snat_ips:


### PR DESCRIPTION
The SG configuration is creating issues with floating
IP traffic and is hence being disabled for EPs which
carry nested container traffic.

Also changed the implementation of list_to_range utility
which was buggy.