### PR TITLE
No security groups for EP carrying nested k8s traffic

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -333,7 +333,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'kubernetes', 'type': 'nested-kubernetes'},
                    'trunk-vlans': [{'start': 2, 'end': 4},
                        {'start': 1000, 'end': 1001},
-                       {'start': 4093, 'end': 4093}]}
+                       {'start': 4093}]}
         uplink_lbiface_file = {
                    "interface-name": 'patch-fabric-ex',
                    "uuid": mock.ANY,
@@ -341,13 +341,35 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'kubernetes', 'type': 'nested-kubernetes'},
                    'trunk-vlans': [{'start': 2, 'end': 4},
                        {'start': 1000, 'end': 1001},
-                       {'start': 4093, 'end': 4093}]}
+                       {'start': 4093}]}
         self.manager._write_endpoint_file.assert_called_once_with(
                 ep_name, ep_file)
         calls = [call(ep_name, lbiface_file),
                  call(ep_name + '_uplink', uplink_lbiface_file)]
         self.assertEqual(2, self.manager._write_lbiface_file.call_count)
         self.manager._write_lbiface_file.assert_has_calls(calls)
+
+    def test_list_to_ranges(self):
+        li = [1, 2, 3, 3000, 4093]
+        exp_rng = [{'start': 1, 'end': 3},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [1, 2, 3, 3000, 0, 4093, 3000]
+        exp_rng = [{'start': 1, 'end': 3},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [1, 2, 3000, 0, -2, 4093, 4094, 5000, 3000]
+        exp_rng = [{'start': 1, 'end': 2},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
+        li = [3000, 1, 4093]
+        exp_rng = [{'start': 1},
+                   {'start': 3000}, {'start': 4093}]
+        rng = self.manager._list_to_range(li)
+        self.assertEqual(exp_rng, rng)
 
     def test_port_multiple_ep_files(self):
         # Prepare AAP list


### PR DESCRIPTION
The SG configuration is creating issues with floating
IP traffic and is hence being disabled for EPs which
carry nested container traffic.

Also changed the implementation of list_to_range utility
which was buggy.

(cherry picked from commit e623f744aa26ce0c05d98f02bec9f7b1d5a8d9ef)
(cherry picked from commit fffd9730e3d84f102d60670ec6596ba6ec0534a1)