### PR TITLE
To support Queens

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -757,6 +757,7 @@ def init_env():
     cfg.CONF.register_opts(gbp_opts, "OPFLEX")
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
+    config.setup_privsep()
     utils.log_opt_values(LOG)
 
 

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -647,6 +647,7 @@ def main():
     config.register_root_helper(cfg.CONF)
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
+    config.setup_privsep()
     q_utils.log_opt_values(LOG)
 
     agent_mode = cfg.CONF.OPFLEX.agent_mode

--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -139,10 +139,10 @@ class NetworkMetadataProxyHandler(object):
 class ProxyDaemon(daemon.Daemon):
     def __init__(self, pidfile, port, network_id=None, router_id=None,
                  domain_id=None,
-                 user=None, group=None, watch_log=True, host="0.0.0.0"):
+                 user=None, group=None, host="0.0.0.0"):
         uuid = domain_id or network_id or router_id
         super(ProxyDaemon, self).__init__(pidfile, uuid=uuid, user=user,
-                                          group=group, watch_log=watch_log)
+                                          group=group)
         self.network_id = network_id
         self.router_id = router_id
         self.domain_id = domain_id
@@ -199,11 +199,6 @@ def main():
                    default=None,
                    help=_("Group (gid or name) running metadata proxy after "
                           "its initialization")),
-        cfg.BoolOpt('metadata_proxy_watch_log',
-                    default=True,
-                    help=_("Watch file log. Log watch should be disabled when "
-                           "metadata_proxy_user/group has no read/write "
-                           "permissions on metadata proxy log file.")),
     ]
 
     cfg.CONF.register_cli_opts(opts)
@@ -219,7 +214,6 @@ def main():
                         domain_id=cfg.CONF.domain_id,
                         user=cfg.CONF.metadata_proxy_user,
                         group=cfg.CONF.metadata_proxy_group,
-                        watch_log=cfg.CONF.metadata_proxy_watch_log,
                         host=cfg.CONF.metadata_host)
 
     if cfg.CONF.daemonize:

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -72,12 +72,14 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         """Override parent setup integration bridge."""
         self.int_br.create()
         self.int_br.set_secure_mode()
-        self.int_br.set_protocols(protocols='[]')
+        self.int_br.set_db_attribute('Bridge', self.int_br.br_name,
+                                     'protocols', '[]', check_error=True)
         #self.int_br.reset_ofversion()
 
         self.fabric_br.create()
         self.fabric_br.set_secure_mode()
-        self.fabric_br.set_protocols(protocols='[]')
+        self.fabric_br.set_db_attribute('Bridge', self.fabric_br.br_name,
+                                        'protocols', '[]', check_error=True)
 
         # Add a canary flow to int_br to track OVS restarts
         self.int_br.add_flow(table=constants.CANARY_TABLE, priority=0,


### PR DESCRIPTION
1. call config.setup_privsep() to set up priviledge separation daemon
properly.
2. watch_log parameter has been removed in Queens.
3. set_protocols() API has been removed in Queens.