### PR TITLE
Fix for upstream iptables changes

### DIFF
--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -15,13 +15,17 @@ import signal
 import sys
 import time
 
+# We need to ensure that the monkey-patch gets applied
+# before other packages that use eventlet get imported
+from neutron.common import eventlet_utils  # noqa
+eventlet_utils.monkey_patch()
+
 from neutron.agent.common import ip_lib
 from neutron.agent.common import polling
 from neutron.agent.linux import iptables_firewall
 from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as sg_rpc
 from neutron.common import config as common_config
-from neutron.common import eventlet_utils
 from neutron.common import topics
 from neutron.common import utils as q_utils
 from neutron.conf.agent import common as config
@@ -48,7 +52,6 @@ from oslo_log import log as logging
 from oslo_service import loopingcall
 from oslo_utils import excutils
 
-eventlet_utils.monkey_patch()
 LOG = logging.getLogger(__name__)
 
 DVS_AGENT_MODULE = 'vmware_dvs.agent.dvs_neutron_agent'


### PR DESCRIPTION
Commits in upstream neutron ([0], [1]) enabled multi-threaded processing
of iptables entries in agents, in order to improve performance. These
changes caused exceptions in the neutron-opflex-agent, since they were
included before the eventlet monkey-patch was executed. This patch
moves the eventlet monkey-patch to before any of the neutron packages
are included, avoiding the threading exceptions.

[0] a521bf0393d33d6e69f59900942404c2b5c84d83
[1] 65a81623fc0377b26d2d5800607f7c3acc08c45a

(cherry picked from commit d6a2fa0c8c77725cd8b94d07932caf87e162cc32)