### PR TITLE
SNAT conn track logging feature

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -67,6 +67,12 @@ gbp_opts = [
                default='ovs',
                help=_("The class to use for OVS bridge management. "
                       "Options are: 'ovs' (default), 'vpp' and 'fake'.")),
+    cfg.StrOpt('conn_track_syslog_facility', default='user',
+               help=_("The syslog facility used by opflex-conn-track "
+                      "program")),
+    cfg.StrOpt('conn_track_syslog_severity', default='info',
+               help=_("The syslog severity used by opflex-conn-track "
+                      "program")),
 ]
 
 vpp_opts = [

--- a/opflexagent/opflex_conn_track.py
+++ b/opflexagent/opflex_conn_track.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import subprocess
+import sys
+
+from neutron.common import config
+from neutron.common import utils as comm_utils
+from oslo_log import log
+
+
+LOG = log.getLogger(__name__)
+
+
+def sh(cmd):
+    LOG.debug("conn_track: Running command: %s" % cmd)
+    ret = ''
+    try:
+        ret = subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT, shell=True)
+    except Exception as e:
+        LOG.error("In running command: %s: %s" % (cmd, str(e)))
+    LOG.debug("conn_track: Command output: %s" % ret)
+    return ret
+
+
+# This program takes 3 parameters,
+# 1st is the SNAT network namespace name.
+# 2nd is the syslog facility name.
+# 3rd is the syslog severity level.
+def main():
+    config.setup_logging()
+    comm_utils.log_opt_values(LOG)
+    command = ("ip netns exec %s conntrack -E -o timestamp 2>&1 | logger "
+               "-p %s.%s -t conn_track") % (
+                   sys.argv[1], sys.argv[2], sys.argv[3])
+    LOG.debug("conn_track command: %s" % command)
+    sh(command)
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/rpm/neutron-opflex-agent.spec.in
+++ b/rpm/neutron-opflex-agent.spec.in
@@ -96,6 +96,7 @@ usermod -a -G opflexep neutron
 %{_bindir}/opflex-state-watcher
 %{_bindir}/neutron-cisco-apic-host-agent
 %{_bindir}/opflex-ns-proxy
+%{_bindir}/opflex-conn-track
 %{_sysconfdir}/neutron/rootwrap.d/gbp-opflex.filters
 %{_sysconfdir}/neutron/rootwrap.d/cisco-apic.filters
 %{_unitdir}/%{opflex_agent}

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setuptools.setup(
                 'opflexagent.apic_topology:agent_main',
             'opflex-ns-proxy = '
                 'opflexagent.namespace_proxy:main',
+            'opflex-conn-track = '
+                'opflexagent.opflex_conn_track:main',
         ],
         'neutron.ml2.type_drivers': [
             'opflex = opflexagent.type_opflex:OpflexTypeDriver',


### PR DESCRIPTION
1. We will launch/terminate the opflex-conn-track process
thru supervisord when snat netns is being created/deleted.

2. The real command is in opflex_conn_track.py where it
pipes the conntrack output to syslog.

(cherry picked from commit 054bbfcd296fa3352b0bff2ef5fc862552a9591e)
(cherry picked from commit 60138b377b87ccbe5efcd320f39c6aade11090ed)
(cherry picked from commit 872e1a35b09b0e538525fbb06fff91252d4188b6)