### PR TITLE
Fix notify path for Ganga agent

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -50,7 +50,7 @@ gbp_opts = [
                help=_("Set the mode of the agent to be used. Options are: "
                       "'opflex' (default), 'dvs', and 'dvs_no_binding'.")),
     cfg.StrOpt('opflex_notify_socket_path',
-               default='/var/run/opflex-agent-ovs-notif.sock',
+               default='/var/run/opflex-agent-notif.sock',
                help=_("Path of the Opflex notification socket.")),
     cfg.IntOpt('nat_mtu_size', default=0,
                help=_("MTU size of the NAT namespace interface.")),


### PR DESCRIPTION
The Ganga release of opflex-agent changed the path for the
notify socket from /var/run/opflex-agent-ovs-notif.sock to
/var/run/opflex-agent-notif.sock. The default value for this
socket should be changed, as the Ganga agent is used for all
new releases.