### PR TITLE
Add VRF notify RPC

### DIFF
--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -187,6 +187,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                      [topics.PORT, topics.DELETE],
                      [topics.SECURITY_GROUP, topics.UPDATE],
                      [topics.SUBNET, topics.UPDATE],
+                     [rpc.TOPIC_OPFLEX, rpc.NOTIFY_VRF, topics.UPDATE],
                      [rpc.TOPIC_OPFLEX, rpc.VRF, topics.UPDATE]]
         self.connection = agent_rpc.create_consumers(
             self.endpoints, self.topic, consumers, start_listening=False)

--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -21,15 +21,16 @@ LOG = logging.getLogger(__name__)
 TOPIC_OPFLEX = 'opflex'
 ENDPOINT = 'endpoint'
 VRF = 'vrf'
+NOTIFY_VRF = 'notify-vrf'
 
 
 class AgentNotifierApi(object):
     """Server side notification API:
 
-    - Version 1.2: add opflex update
+    - Version 1.3: add notify vrf
     """
 
-    BASE_RPC_API_VERSION = '1.2'
+    BASE_RPC_API_VERSION = '1.3'
 
     def __init__(self, topic):
         target = oslo_messaging.Target(
@@ -41,6 +42,8 @@ class AgentNotifierApi(object):
                                                        topics.DELETE)
         self.topic_subnet_update = topics.get_topic_name(topic, topics.SUBNET,
                                                          topics.UPDATE)
+        self.topic_opflex_notify_vrf = topics.get_topic_name(
+            topic, TOPIC_OPFLEX, NOTIFY_VRF, topics.UPDATE)
         self.topic_opflex_endpoint_update = topics.get_topic_name(
             topic, TOPIC_OPFLEX, ENDPOINT, topics.UPDATE)
         self.topic_opflex_vrf_update = topics.get_topic_name(
@@ -58,6 +61,11 @@ class AgentNotifierApi(object):
         cctxt = self.client.prepare(fanout=True,
                                     topic=self.topic_subnet_update)
         cctxt.cast(context, 'subnet_update', subnet=subnet)
+
+    def opflex_notify_vrf(self, context, vrf):
+        cctxt = self.client.prepare(fanout=True,
+                                    topic=self.topic_opflex_notify_vrf)
+        cctxt.cast(context, 'opflex_notify_vrf', vrf=vrf)
 
     def opflex_endpoint_update(self, context, details, host=None):
         cctxt = self.client.prepare(
@@ -242,12 +250,16 @@ class OpenstackRpcMixin(object):
     """A mix-in that enable Opflex agent
     support in agent implementations.
     """
-    target = oslo_messaging.Target(version='1.2')
+    target = oslo_messaging.Target(version='1.3')
 
     def subnet_update(self, context, subnet):
         self.updated_vrf.add(subnet['tenant_id'])
         LOG.debug("subnet_update message processed for subnet %s",
                   subnet['id'])
+
+    def opflex_notify_vrf(self, context, vrf):
+        self.updated_vrf.add(vrf)
+        LOG.debug("opflex_notify_vrf message processed for vrf %s", vrf)
 
     def port_update(self, context, **kwargs):
         port = kwargs.get('port')

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -455,3 +455,8 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.assertFalse(self.agent.ep_manager._mapping_to_file.called)
         self.agent.ep_manager._mapping_cleanup.assert_called_once_with(
             port_details['device'])
+
+    def test_vrf_update(self):
+        fake_vrf = 'coke-tenant coke-vrf'
+        self.agent.opflex_notify_vrf(mock.Mock(), fake_vrf)
+        self.assertEqual(set(['coke-tenant coke-vrf']), self.agent.updated_vrf)


### PR DESCRIPTION
This adds an RPC notification for VRF updates. The notification
causes the agent to make its request_vrf_details RPC, in order
to retrieve any changes to the subnets located in this VRF.