### PR TITLE
Fix AsMetadata Manager init

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -29,6 +29,7 @@ from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
+from opflexagent.utils import utils as opflexagent_utils
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
@@ -527,9 +528,9 @@ class StateWatcher(FileWatcher):
 
 
 class SnatConnTrackHandler(object):
-    def __init__(self, bridge_manager):
+    def __init__(self):
         root_helper = cfg.CONF.AGENT.root_helper
-        self.mgr = AsMetadataManager(LOG, root_helper, bridge_manager)
+        self.mgr = AsMetadataManager(LOG, root_helper)
         self.syslog_facility = cfg.CONF.OPFLEX.conn_track_syslog_facility
         self.syslog_severity = cfg.CONF.OPFLEX.conn_track_syslog_severity
 
@@ -573,13 +574,14 @@ class SnatConnTrackHandler(object):
 
 
 class AsMetadataManager(object):
-    def __init__(self, logger, root_helper, bridge_manager):
+    def __init__(self, logger, root_helper):
         global LOG
         LOG = logger
         self.root_helper = root_helper
         self.name = "AsMetadataManager"
         self.md_filename = "%s/%s" % (MD_DIR, MD_SUP_FILE_NAME)
-        self.bridge_manager = bridge_manager
+        self.bridge_manager = opflexagent_utils.get_bridge_manager(
+                              cfg.CONF.OPFLEX)
         self.initialized = False
 
     def init_all(self):

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -30,7 +30,7 @@ class SnatIptablesManager(object):
     def __init__(self, bridge_manager):
         self.bridge_manager = bridge_manager
         self.snat_conn_track_handler = (
-            as_metadata_manager.SnatConnTrackHandler(bridge_manager))
+            as_metadata_manager.SnatConnTrackHandler())
 
     def _cleanup(self, if_name, ns_name):
         self.bridge_manager.delete_port(if_name)

--- a/opflexagent/utils/bridge_managers/bridge_manager_base.py
+++ b/opflexagent/utils/bridge_managers/bridge_manager_base.py
@@ -102,6 +102,7 @@ class BridgeManagerBase(object):
         :return set of ep to be removed
         """
 
+    @staticmethod
     @abc.abstractmethod
     def plug_metadata_port(self, dst_shell, port):
         """

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -17,8 +17,8 @@ from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import ovs_lib
 from opflexagent.utils.bridge_managers import trunk_skeleton
+from oslo_config import cfg
 from oslo_log import log as logging
-
 
 LOG = logging.getLogger(__name__)
 DEAD_VLAN_TAG = n_constants.MAX_VLAN_TAG + 1
@@ -169,7 +169,8 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         return removed_eps
 
     def plug_metadata_port(self, dst_shell, port):
-        dst_shell("ovs-vsctl add-port %s %s" % (self.fabric_br.br_name, port))
+        dst_shell("ovs-vsctl add-port %s %s" % (
+                  cfg.CONF.OPFLEX.fabric_bridge, port))
 
     def delete_port(self, port):
         self.fabric_br.delete_port(port)

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -1,0 +1,35 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron_lib.utils import runtime
+from opflexagent.utils.bridge_managers import (
+    bridge_manager_base as bridge_manager)
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+def get_bridge_manager(conf):
+    """Get Bridge Manager.
+
+    :param conf: bridge manager configuration object
+    :raises SystemExit of 1 if driver cannot be loaded
+    """
+
+    try:
+        loaded_class = runtime.load_class_by_alias_or_classname(
+                bridge_manager.BRIDGE_MANAGER_NAMESPACE, conf.bridge_manager)
+        return loaded_class()
+    except ImportError:
+        LOG.error(_("Error loading bridge manager '%s'"),
+                  conf.bridge_manager)
+        raise SystemExit(1)


### PR DESCRIPTION
In cases where AsMetaDataManager is not started from opflex_agent,
we can directly get the correct bridge_manager class to load
and create the metadata port on the bridge from config_opts.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 9768704f80ca000c526720ed83c04f6150122b86)
(cherry picked from commit 5f1e4f94602c43a1b431a27e1aa559dc70d36b5c)