### PR TITLE
Fix endpoint details response

### DIFF
--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -69,7 +69,7 @@ class AgentNotifierApi(object):
 
     def opflex_endpoint_update(self, context, details, host=None):
         cctxt = self.client.prepare(
-            fanout=True, topic=self.topic_opflex_endpoint_update, server=host)
+            topic=self.topic_opflex_endpoint_update, server=host)
         cctxt.cast(context, 'opflex_endpoint_update', details=details)
 
     def opflex_vrf_update(self, context, details):


### PR DESCRIPTION
The response to the request_endpoint_details_list RPC is the
opflex_notify message. This currently is using a cast with fanout,
meaning all agents receive this message. However, the requests for
the details are made by individual agents, and each agent assigns
a UUID for the request. When the responses are received, any response
without a matching request is dropped by the agent, ensuring that each
agent only processes repsonses to its requests. This means there is no
purpose in sending the responses as broadcast messages. This patch
removes the fanout, ensuring that only the agent that requested the
message receives it.

(cherry picked from commit a6d8224eb2dc30b68b7631576f7ef35a6b83d615)