### PR TITLE
Fix for conntrack logging

### DIFF
--- a/opflexagent/opflex_conn_track.py
+++ b/opflexagent/opflex_conn_track.py
@@ -45,9 +45,7 @@ def main():
                "-p %s.%s -t opflex-conn-track") % (
                    sys.argv[1], sys.argv[2], sys.argv[3])
     LOG.debug("conn_track command: %s" % command)
-    sh(command)
-
-    return
+    return sh(command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The SNAT conntrack logging processes weren't getting restarted
if killed. This was because the return code of the conntrack
command wasn't being propagated, so the opflex-conn-track command
returned an exit status of 0, indicating normal termination.