### PR TITLE
Add fix for bad port details

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1074,3 +1074,11 @@ class TestEndpointFileManager(base.OpflexTestBase):
         self.manager.declare_endpoint(port, mapping)
         self.manager._write_endpoint_file.assert_called_with(ep_name, ep_file)
         self.manager.bridge_manager.get_port_vif_name = old_method
+
+    def test_bad_mapping(self):
+        mapping = self._get_gbp_details()
+        port_1 = self._port()
+
+        # Get rid of the EPG, verify we don't get an exception
+        mapping['endpoint_group_name'] = None
+        self.manager.declare_endpoint(port_1, mapping)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -114,7 +114,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
         if not mapping:
             return
-        else:
+        try:
             # Multiple files will be created based on how many MAC
             # addresses are owned by the specific port.
             mapping_copy = copy.deepcopy(mapping)
@@ -204,6 +204,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                                   mac_exceptions=macs)
             self._registered_endpoints.add(port.vif_id)
             self.vif_int_dict.update({port.vif_id: port.port_name})
+        except Exception as e:
+            LOG.exception(_("Error while parsing ep file for "
+                            "port %(port)s: %(ex)s"), {'port': port, 'ex': e})
 
     def undeclare_endpoint(self, port_id):
         LOG.info(_LI("Endpoint undeclare requested for port %s"), port_id)


### PR DESCRIPTION
If there is an exception constructing the EP file, catch it so
that the agent won't get stuck in an endless loop of restarts
and declarations.

(cherry picked from commit f18a9e60740cb8aba25ba944e9f6076c6d33c3e5)
(cherry picked from commit 2a98b062e3c74226d1df6fa984ae065cbb029842)
(cherry picked from commit 5f725758e99c0267d31cb1374b25e67d05a49949)