### PR TITLE
Send port_update notification to bound host only

### DIFF
--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -50,9 +50,11 @@ class AgentNotifierApi(object):
             topic, TOPIC_OPFLEX, VRF, topics.UPDATE)
 
     def port_update(self, context, port):
-        cctxt = self.client.prepare(fanout=True, topic=self.topic_port_update,
-                                    version='1.1')
-        cctxt.cast(context, 'port_update', port=port)
+        host = port.get('binding:host_id')
+        if host:
+            cctxt = self.client.prepare(
+                server=host, topic=self.topic_port_update, version='1.1')
+            cctxt.cast(context, 'port_update', port=port)
 
     def port_delete(self, context, port):
         cctxt = self.client.prepare(fanout=True, topic=self.topic_port_delete,


### PR DESCRIPTION
When a port is updated, there is generally no need to notify opflex agents on hosts other than the one where the port is bound. Therefore, instead of sending a fanout cast, the port_update notification is sent only to the server where the port is currently bound.

We need to ensure that during VM migration, we are not dependent on the old bound host getting a notification after the port has been rebound to the new host.