### PR TITLE
Additional fields on EP file for VMs on SVI networks

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1084,3 +1084,23 @@ class TestEndpointFileManager(base.OpflexTestBase):
         # Get rid of the EPG, verify we don't get an exception
         mapping['endpoint_group_name'] = None
         self.manager.declare_endpoint(port_1, mapping)
+
+    def test_svi_port_bound(self):
+        # the SVI related info we expect to see
+        # on get_gbp_details
+        svi_info = {}
+        svi_info['svi'] = True
+        svi_info['svi_vlan'] = 1234
+        svi_info['endpoint_group_name'] = 'svi-net-id'
+
+        mapping = self._get_gbp_details(**svi_info)
+        port = self._port()
+
+        self.manager.declare_endpoint(port, mapping)
+        epargs = self.manager._write_endpoint_file.call_args_list
+
+        self.assertEqual(svi_info['svi'], epargs[1][0][1].get('ext-svi'))
+        self.assertEqual(svi_info['svi_vlan'],
+            epargs[1][0][1].get('ext-encap-id'))
+        self.assertEqual(svi_info['endpoint_group_name'],
+            epargs[1][0][1].get('endpoint-group-name'))

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -312,11 +312,6 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                                                                 port.vif_id)
         mapping_dict = {
             "policy-space-name": mapping['ptg_tenant'],
-            "endpoint-group-name": (mapping['app_profile_name'] + "|" +
-                                    mapping['endpoint_group_name']),
-            "eg-mapping-alias": "%s_%s_%s" % (mapping['ptg_tenant'],
-                                              mapping['app_profile_name'],
-                                              mapping['endpoint_group_name']),
             "access-interface": access_interface,
             "access-uplink-interface": port_f,
             "interface-name": port_i,
@@ -326,6 +321,23 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             'neutron-metadata-optimization':
                 mapping['enable_metadata_optimization'],
         }
+        if mapping.get('svi'):
+            # VM on SVI type network, in addition to the flag and
+            # vlan-id, epg is set to a unique id so using the network
+            # id provided in this field in the response to gbp details.
+            mapping_dict['endpoint-group-name'] = (
+                mapping['endpoint_group_name'])
+            mapping_dict['eg-mapping-alias'] = None
+            mapping_dict['ext-svi'] = True
+            mapping_dict['ext-encap-id'] = mapping.get('svi_vlan')
+        else:
+            mapping_dict['endpoint-group-name'] = (
+                mapping['app_profile_name'] + "|" +
+                mapping['endpoint_group_name'])
+            mapping_dict['eg-mapping-alias'] = "%s_%s_%s" % (
+                mapping['ptg_tenant'],
+                mapping['app_profile_name'],
+                mapping['endpoint_group_name'])
         if vlan:
             mapping_dict['access-interface-vlan'] = vlan
         ips = [x['ip_address'] for x in fixed_ips]


### PR DESCRIPTION
We now support VM instantiation on an SVI network on hosts
running opflex-agent. To support the associated data path changes
additional fields are introduced in the EP file as:
- ext-svi             : flag to indicate that the network is of
                        type SVI
- ext-encap-id        : indicates the vlan-id
- endpoint-group-name : now contains a unique id for an SVI network
                        so we use the network uuid
These are obtained in response to the get_gbp_details rpc.

(cherry picked from commit ef94033c10d1b34e274bed076cb41d1e2fe8f27f)