### PR TITLE
Add vlan type networks to allowed list for opflex agent

### DIFF
--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -110,7 +110,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             agent_conf.ovsdb_monitor_respawn_interval or
             constants.DEFAULT_OVSDBMON_RESPAWN)
         self.setup_report()
-        self.supported_pt_network_types = [ofcst.TYPE_OPFLEX]
+        self.supported_pt_network_types = [
+            ofcst.TYPE_OPFLEX, n_constants.TYPE_VLAN
+        ]
 
         # Initialize iteration counter
         self.iter_num = 0

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -413,15 +413,16 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.agent.bridge_manager.delete_patch_ports.assert_called_with(
             [subports[0].port_id, subports[1].port_id])
 
-    def test_port_bound_to_host(self):
+    def _test_port_bound_to_host(self, net_type):
         mapping = self._get_gbp_details(device='some_device')
+        seg_id = 1234 if net_type is 'vlan' else ''
         port_details = {'device': 'some_device',
                         'admin_state_up': True,
                         'port_id': mapping['port_id'],
                         'network_id': 'some-net',
-                        'network_type': 'opflex',
+                        'network_type': net_type,
                         'physical_network': 'phys_net',
-                        'segmentation_id': '',
+                        'segmentation_id': seg_id,
                         'fixed_ips': [],
                         'device_owner': 'some-vm'}
         self.agent.plugin_rpc.update_device_up = mock.Mock()
@@ -455,6 +456,12 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.assertFalse(self.agent.ep_manager._mapping_to_file.called)
         self.agent.ep_manager._mapping_cleanup.assert_called_once_with(
             port_details['device'])
+
+    def test_port_bound_to_host_net_opflex(self):
+        self._test_port_bound_to_host('opflex')
+
+    def test_port_bound_to_host_net_vlan(self):
+        self._test_port_bound_to_host('vlan')
 
     def test_vrf_update(self):
         fake_vrf = 'coke-tenant coke-vrf'


### PR DESCRIPTION
With support for SVI we need to allow vlan type networks.

(cherry picked from commit 27582e8dd791c57427e1218e417ad4396736d491)