### PR TITLE
Adapt to change in location of segmentation_id in _get_gbp_details re…

### DIFF
--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -187,10 +187,11 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 port_info.get('vrf_updated'))
 
     def try_port_binding(self, port, net_uuid, network_type, physical_network,
-                         fixed_ips, device_owner):
+                         fixed_ips, device_owner, segmentation_id):
         port.net_uuid = net_uuid
         port.device_owner = device_owner
         port.fixed_ips = fixed_ips
+        port.segmentation_id = segmentation_id
         if not port.gbp_details:
             # Mapping is empty, this port left the Opflex policy space.
             LOG.warn("Mapping for port %s is None, undeclaring the Endpoint",
@@ -371,7 +372,8 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                                     neutron_details['physical_network'],
                                     neutron_details['admin_state_up'],
                                     neutron_details['fixed_ips'],
-                                    neutron_details['device_owner'])
+                                    neutron_details['device_owner'],
+                                    neutron_details['segmentation_id'])
                 # update plugin about port status
                 if neutron_details.get('admin_state_up'):
                     LOG.debug(_("Setting status for %s to UP"), device)
@@ -398,7 +400,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
     def treat_vif_port(self, vif_port, port_id, network_id, network_type,
                        physical_network, admin_state_up,
-                       fixed_ips, device_owner):
+                       fixed_ips, device_owner, segmentation_id):
         # When this function is called for a port, the port should have
         # an OVS ofport configured, as only these ports were considered
         # for being treated. If that does not happen, it is a potential
@@ -410,7 +412,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             if admin_state_up:
                 self.try_port_binding(vif_port, network_id, network_type,
                                       physical_network, fixed_ips,
-                                      device_owner)
+                                      device_owner, segmentation_id)
             else:
                 self.port_unbound(vif_port.vif_id)
         else:

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1088,19 +1088,18 @@ class TestEndpointFileManager(base.OpflexTestBase):
     def test_svi_port_bound(self):
         # the SVI related info we expect to see
         # on get_gbp_details
+        port = self._port()
         svi_info = {}
         svi_info['svi'] = True
-        svi_info['svi_vlan'] = 1234
         svi_info['endpoint_group_name'] = 'svi-net-id'
 
         mapping = self._get_gbp_details(**svi_info)
-        port = self._port()
-
+        port.segmentation_id = 1234
         self.manager.declare_endpoint(port, mapping)
         epargs = self.manager._write_endpoint_file.call_args_list
 
         self.assertEqual(svi_info['svi'], epargs[1][0][1].get('ext-svi'))
-        self.assertEqual(svi_info['svi_vlan'],
+        self.assertEqual(port.segmentation_id,
             epargs[1][0][1].get('ext-encap-id'))
         self.assertEqual(svi_info['endpoint_group_name'],
             epargs[1][0][1].get('endpoint-group-name'))

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -70,7 +70,8 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                                'ip_address': '192.168.0.2'},
                               {'subnet_id': 'id2',
                                'ip_address': '192.168.1.2'}],
-                'device_owner': 'compute:'}
+                'device_owner': 'compute:',
+                'segmentation_id': ''}
 
     def _purge_endpoint_dir(self):
         try:

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -286,7 +286,6 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         Converts the port mapping into file.
         """
         # Skip router-interface ports - they interfere with OVS pipeline
-
         fixed_ips = mapping.get('fixed_ips') or fixed_ips
         # Routing is handled by ACI
         if port.device_owner in [n_constants.DEVICE_OWNER_ROUTER_INTF]:
@@ -329,7 +328,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 mapping['endpoint_group_name'])
             mapping_dict['eg-mapping-alias'] = None
             mapping_dict['ext-svi'] = True
-            mapping_dict['ext-encap-id'] = mapping.get('svi_vlan')
+            mapping_dict['ext-encap-id'] = port.segmentation_id
         else:
             mapping_dict['endpoint-group-name'] = (
                 mapping['app_profile_name'] + "|" +


### PR DESCRIPTION
…sponse

- The segmentation_id is provided in the neutron_details portion of the response
  instead of the original plan to be in the gbp portion. We tweak the handling to
  account for this.
- Fixups to relevant UTs.
- Fixups to other UTs to account for side effects due to the change.

(cherry picked from commit cef50b2c5a74952159a21adc66504f49fa057052)