### PR TITLE
Fix SNAT EP file handling

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -721,8 +721,13 @@ class TestEndpointFileManager(base.OpflexTestBase):
         self.manager._write_file('uuid1_CC', {}, self.manager.epg_mapping_file)
         self.manager._write_file('uuid2_BB', {}, self.manager.epg_mapping_file)
         self.manager._write_file('uuid2_BB', {}, self.manager.epg_mapping_file)
-        with mock.patch.object(snat_iptables_manager.SnatIptablesManager,
-                               'cleanup_snat_all'):
+
+        def dummy_check(self, es):
+            return False
+
+        with mock.patch.multiple(snat_iptables_manager.SnatIptablesManager,
+                                 cleanup_snat_all=mock.DEFAULT,
+                                 check_if_exists=dummy_check):
             manager = self._initialize_agent()
             self._mock_agent(manager)
             self.assertEqual(set(['uuid1', 'uuid2']),

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -301,6 +301,9 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                     snat_iptables_manager.SnatIptablesManager,
                     'cleanup_snat_all'),
                 mock.patch.object(
+                    snat_iptables_manager.SnatIptablesManager,
+                    'check_if_exists', return_value=False),
+                mock.patch.object(
                     endpoint_file_manager.EndpointFileManager,
                     'undeclare_endpoint'),
                 mock.patch.object(ovs.OVSPluginApi, 'update_device_down')):

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -119,6 +119,8 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.ep_manager._delete_endpoint_file = mock.Mock()
         agent.ep_manager._delete_vrf_file = mock.Mock()
         agent.ep_manager.snat_iptables = mock.Mock()
+        agent.ep_manager.snat_iptables.check_if_exists = mock.Mock(
+            return_value=False)
         agent.ep_manager.snat_iptables.setup_snat_for_es = mock.Mock(
             return_value = tuple([None, None]))
         agent.ep_manager._release_int_fip = mock.Mock()
@@ -289,6 +291,9 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 mock.patch.object(
                     snat_iptables_manager.SnatIptablesManager,
                     'cleanup_snat_all'),
+                mock.patch.object(
+                    snat_iptables_manager.SnatIptablesManager,
+                    'check_if_exists', return_value=False),
                 mock.patch.object(
                     endpoint_file_manager.EndpointFileManager,
                     'undeclare_endpoint'),


### PR DESCRIPTION
After a restart, the agent scans the files in the endpoints directory
and compares them against ports on the vSwitch, in order to create a
list of "stale" EPs which can be removed. The current processing
assumes that files with an underscore in the name are EP files for
non-service ports. This criteria is inadequate, since the the name of
SNAT service ports is constructed using the name of the l3extInstP
(the External EPG/Network under the L3 Out) used when creating the
neutron external network. This leads to falsely considering SNAT EP files
as non-service EP files, and prevents the SNAT EP file from being added
to the list of existing SNAT external segments (the "exclude_es" list),
causing the SNAT EP file and namespace to (erroneously) be deleted.

This patch re-orders the stale EP file processing, so that files are
first checked to see if they are for an SNAT namespace/service first,
before considering them for non-service EPs.

The code should probably be changed at some point to consider a more
reliable way of determining non-service EP files, possibly through
the addition of an explicit property.

closes noironetworks/support#1077

(cherry picked from commit 52d120ca49623a9dbfb90a6b6b4e4a19044b6e9f)