### PR TITLE
Fix OVS option registration

### DIFF
--- a/opflexagent/utils/bridge_managers/ovs_lib.py
+++ b/opflexagent/utils/bridge_managers/ovs_lib.py
@@ -14,6 +14,9 @@ import contextlib
 
 from neutron.agent.common import ovs_lib
 from neutron.agent.ovsdb import impl_vsctl
+from neutron.plugins.ml2.drivers.openvswitch.agent.common import config
+
+from opflexagent import config  # noqa
 
 
 class OVSBridge(ovs_lib.OVSBridge):


### PR DESCRIPTION
The upstream OVS configuration options weren't being referenced
at the time of import ofr the OVS bridge manager, which resulted
in exceptions like the following:

oslo_config.cfg.NoSuchOptError: no such option bridge_mappings in group [OVS]

This patch imports the appropriate libraries to ensure that the configuration
options are loaded so that they can be used when the OVS bridge manager
is loaded.