### PR TITLE
python-opflex-agent supports py36

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -17,8 +17,8 @@ import netaddr
 import os
 import os.path
 import pyinotify
-import Queue
 import signal
+from six.moves import queue as Queue
 import subprocess
 import sys
 import time

--- a/opflexagent/test/test_agent_types.py
+++ b/opflexagent/test/test_agent_types.py
@@ -38,10 +38,11 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             'opflexagent.as_metadata_manager.AsMetadataManager')
         metadata_patch = metadata_mgr.start()
         cfg.CONF.set_override('agent_mode', 'opflex', 'OPFLEX')
-        with mock.patch('sys.argv'):
-            gbp_agent.main()
-            self.assertEqual(1, opflex_patch.call_count)
-            self.assertEqual(1, metadata_patch.call_count)
+        with mock.patch('os.path.basename'):
+            with mock.patch('sys.argv'):
+                gbp_agent.main()
+                self.assertEqual(1, opflex_patch.call_count)
+                self.assertEqual(1, metadata_patch.call_count)
         opflex_agent.stop()
         metadata_mgr.stop()
 
@@ -51,11 +52,12 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
                                  return_value=mock_dvs_instance)
         import_patch = import_mock.start()
         cfg.CONF.set_override('agent_mode', 'dvs', 'OPFLEX')
-        with mock.patch('sys.argv'):
-            gbp_agent.main()
-            self.assertEqual(1, import_patch.call_count)
-            self.assertEqual(
-                1, mock_dvs_instance.create_agent_config_map.call_count)
+        with mock.patch('os.path.basename'):
+            with mock.patch('sys.argv'):
+                gbp_agent.main()
+                self.assertEqual(1, import_patch.call_count)
+                self.assertEqual(
+                    1, mock_dvs_instance.create_agent_config_map.call_count)
         import_mock.stop()
 
     def test_dvs_agent_no_binding_mode(self):
@@ -64,11 +66,12 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
                                  return_value=mock_dvs_instance)
         import_patch = import_mock.start()
         cfg.CONF.set_override('agent_mode', 'dvs_no_binding', 'OPFLEX')
-        with mock.patch('sys.argv'):
-            gbp_agent.main()
-            self.assertEqual(1, import_patch.call_count)
-            self.assertEqual(
-                1, mock_dvs_instance.create_agent_config_map.call_count)
+        with mock.patch('os.path.basename'):
+            with mock.patch('sys.argv'):
+                gbp_agent.main()
+                self.assertEqual(1, import_patch.call_count)
+                self.assertEqual(
+                    1, mock_dvs_instance.create_agent_config_map.call_count)
         import_mock.stop()
 
     def test_dvs_agent_mode_no_package(self):
@@ -76,10 +79,11 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
                                  side_effect=ValueError)
         import_patch = import_mock.start()
         cfg.CONF.set_override('agent_mode', 'dvs', 'OPFLEX')
-        with mock.patch('sys.argv'), mock.patch('sys.exit') as sys_patch:
-            try:
-                gbp_agent.main()
-            except AttributeError:
-                self.assertEqual(1, sys_patch.call_count)
-            self.assertEqual(1, import_patch.call_count)
+        with mock.patch('os.path.basename'):
+            with mock.patch('sys.argv'), mock.patch('sys.exit') as sys_patch:
+                try:
+                    gbp_agent.main()
+                except AttributeError:
+                    self.assertEqual(1, sys_patch.call_count)
+                self.assertEqual(1, import_patch.call_count)
         import_mock.stop()

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -890,7 +890,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
         self.assertEqual(1, len(snat_ep_file))
         snat_ep_file = snat_ep_file[0]
 
-        for k, v in expected.iteritems():
+        for k, v in expected.items():
             self.assertEqual(v, snat_ep_file[k])
 
         self.manager.undeclare_endpoint(port.vif_id)

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -17,7 +17,6 @@ import mock
 sys.modules["apicapi"] = mock.Mock()
 sys.modules["pyinotify"] = mock.Mock()
 
-import contextlib
 from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager
 from opflexagent.test import base
@@ -89,28 +88,31 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             def start(self, interval=0):
                 self.f()
 
-        with contextlib.nested(
-            mock.patch('opflexagent.utils.bridge_managers.ovs_manager.'
+        with mock.patch('opflexagent.utils.bridge_managers.ovs_manager.'
                        'OvsManager.setup_integration_bridge',
-                       return_value=mock.Mock()),
-            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
-                       'create'),
-            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
-                       'set_secure_mode'),
-            mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
-                       'get_local_port_mac',
-                       return_value='00:00:00:00:00:01'),
-            mock.patch('neutron.agent.common.ovs_lib.BaseOVS.get_bridges'),
-            mock.patch('oslo_service.loopingcall.FixedIntervalLoopingCall',
-                       new=MockFixedIntervalLoopingCall),
-            mock.patch('opflexagent.gbp_agent.GBPOpflexAgent.'
-                       '_report_state')):
-            agent = gbp_agent.GBPOpflexAgent(**kwargs)
-            # set back to true because initial report state will succeed due
-            # to mocked out RPC calls
-            agent.use_call = True
-            agent.tun_br = mock.Mock()
-            agent.host = 'host1'
+                       return_value=mock.Mock()):
+            with mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                       'create'):
+                with mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                       'set_secure_mode'):
+                    with mock.patch('neutron.agent.common.ovs_lib.OVSBridge.'
+                        'get_local_port_mac',
+                        return_value='00:00:00:00:00:01'):
+                        with mock.patch('neutron.agent.common.ovs_lib'
+                                '.BaseOVS.get_bridges'):
+                            with mock.patch('oslo_service.loopingcall'
+                                    '.FixedIntervalLoopingCall',
+                                    new=MockFixedIntervalLoopingCall):
+                                with mock.patch('opflexagent.gbp_agent'
+                                        '.GBPOpflexAgent.'
+                                        '_report_state'):
+                                    agent = gbp_agent.GBPOpflexAgent(**kwargs)
+                                    # set back to true because initial report
+                                    # state will succeed due
+                                    # to mocked out RPC calls
+                                    agent.use_call = True
+                                    agent.tun_br = mock.Mock()
+                                    agent.host = 'host1'
         agent.sg_agent = mock.Mock()
         return agent
 
@@ -296,63 +298,69 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             'uuid2_BB', {}, self.agent.ep_manager.epg_mapping_file)
         self.agent.ep_manager._write_file(
             'uuid2_BB', {}, self.agent.ep_manager.epg_mapping_file)
-        with contextlib.nested(
-                mock.patch.object(
+        with mock.patch.object(
                     snat_iptables_manager.SnatIptablesManager,
-                    'cleanup_snat_all'),
-                mock.patch.object(
+                    'cleanup_snat_all'):
+            with mock.patch.object(
                     snat_iptables_manager.SnatIptablesManager,
-                    'check_if_exists', return_value=False),
-                mock.patch.object(
+                    'check_if_exists', return_value=False):
+                with mock.patch.object(
                     endpoint_file_manager.EndpointFileManager,
-                    'undeclare_endpoint'),
-                mock.patch.object(ovs.OVSPluginApi, 'update_device_down')):
-            port_stats = {'regular': {'added': 0,
-                                      'updated': 0,
-                                      'removed': 0},
-                          'ancillary': {'added': 0,
-                                        'removed': 0}}
-            agent = self._initialize_agent()
-            self._mock_agent(agent)
-            agent.bridge_manager.int_br.get_vif_port_set = mock.Mock(
-                return_value=set(['uuid1']))
-            agent._main_loop(set(), True, 1, port_stats, mock.Mock(), True)
-            agent.ep_manager.undeclare_endpoint.assert_called_once_with(
-                'uuid2')
+                    'undeclare_endpoint'):
+                    with mock.patch.object(ovs.OVSPluginApi,
+                        'update_device_down'):
+                        port_stats = {'regular': {'added': 0,
+                                                  'updated': 0,
+                                                  'removed': 0},
+                                      'ancillary': {'added': 0,
+                                                    'removed': 0}}
+                        agent = self._initialize_agent()
+                        self._mock_agent(agent)
+                        agent.bridge_manager \
+                            .int_br.get_vif_port_set = mock.Mock(
+                                return_value=set(['uuid1']))
+                        agent._main_loop(set(), True, 1, port_stats,
+                            mock.Mock(), True)
+                        agent.ep_manager.undeclare_endpoint \
+                            .assert_called_once_with(
+                                'uuid2')
 
     def test_process_deleted_ports(self):
         self.agent.bridge_manager.delete_patch_ports = mock.Mock()
-        with contextlib.nested(
-                mock.patch.object(
+        with mock.patch.object(
                     snat_iptables_manager.SnatIptablesManager,
-                    'cleanup_snat_all'),
-                mock.patch.object(
+                    'cleanup_snat_all'):
+            with mock.patch.object(
                     endpoint_file_manager.EndpointFileManager,
-                    'undeclare_endpoint'),
-                mock.patch.object(ovs.OVSPluginApi, 'update_device_down')):
-            agent = self._initialize_agent()
-            self._mock_agent(agent)
-            port_info = {'current': set(['1', '2']),
-                         'removed': set(['3', '5'])}
-            agent.bridge_manager.scan_ports = mock.Mock(return_value=port_info)
-            agent.bridge_manager.delete_patch_ports = mock.Mock()
-            agent.deleted_ports.add('3')
-            agent.deleted_ports.add('4')
-            port_stats = {'regular': {'added': 0,
-                                      'updated': 0,
-                                      'removed': 0},
-                          'ancillary': {'added': 0,
-                                        'removed': 0}}
-            agent._main_loop(set(), True, 1, port_stats, mock.Mock(), True)
-            # 3, 4 and 5 are undeclared once
-            expected = [mock.call('3'), mock.call('4'), mock.call('5')]
-            self._check_call_list(
-                expected,
-                agent.ep_manager.undeclare_endpoint.call_args_list)
-            expected = [mock.call(['3']), mock.call(['4']), mock.call(['5'])]
-            self._check_call_list(
-                expected,
-                agent.bridge_manager.delete_patch_ports.call_args_list)
+                    'undeclare_endpoint'):
+                with mock.patch.object(ovs.OVSPluginApi,
+                        'update_device_down'):
+                    agent = self._initialize_agent()
+                    self._mock_agent(agent)
+                    port_info = {'current': set(['1', '2']),
+                                 'removed': set(['3', '5'])}
+                    agent.bridge_manager.scan_ports = mock.Mock(
+                        return_value=port_info)
+                    agent.bridge_manager.delete_patch_ports = mock.Mock()
+                    agent.deleted_ports.add('3')
+                    agent.deleted_ports.add('4')
+                    port_stats = {'regular': {'added': 0,
+                                              'updated': 0,
+                                              'removed': 0},
+                                  'ancillary': {'added': 0,
+                                                'removed': 0}}
+                    agent._main_loop(set(), True, 1, port_stats, mock.Mock(),
+                        True)
+                    # 3, 4 and 5 are undeclared once
+                    expected = [mock.call('3'), mock.call('4'), mock.call('5')]
+                    self._check_call_list(
+                        expected,
+                        agent.ep_manager.undeclare_endpoint.call_args_list)
+                    expected = [mock.call(['3']), mock.call(['4']),
+                        mock.call(['5'])]
+                    self._check_call_list(
+                        expected,
+                        agent.bridge_manager.delete_patch_ports.call_args_list)
 
     def test_process_vrf_update(self):
         self.agent.ep_manager._delete_vrf_file = mock.Mock()

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -174,7 +174,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             mapping_copy['enable_metadata_optimization'] = True
             mapping_copy['promiscuous_mode'] = False
             # Map to file based on the AAP with a MAC address
-            for mac, aaps in mac_aap_map.iteritems():
+            for mac, aaps in mac_aap_map.items():
                 # Get extra details for this mac (if any)
                 extra_details = mapping.get('extra_details', {}).get(mac,
                                                                      {})
@@ -253,7 +253,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     # as stale or not.
                     elif '_' in f:
                         self._registered_endpoints.add(f.split('_')[0])
-                        fp = file(os.path.join(directory, f))
+                        fp = open(os.path.join(directory, f))
                         try:
                             ep_opts = json.load(fp)
                             access_int = ep_opts['access-interface']
@@ -507,7 +507,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
     def _list_to_range(self, vlans_list):
         vlans_list = list(set(vlans_list))
-        vlans_list = filter(lambda a: a > 0 and a < 4094, vlans_list)
+        vlans_list = list(filter(lambda a: a > 0 and a < 4094, vlans_list))
         vlans_list.sort()
         vlan_ranges = []
         while vlans_list:
@@ -606,9 +606,10 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 dhcp4['lease-time'] = mapping['dhcp_lease_time']
             mapping_dict['dhcp4'] = dhcp4
             break
-        if len(v6subnets) > 0 and v6subnets.values()[0]['dns_nameservers']:
+        if len(v6subnets) > 0 and list(v6subnets.values())[0][
+            'dns_nameservers']:
             mapping_dict['dhcp6'] = {
-                'dns-servers': v6subnets.values()[0]['dns_nameservers']}
+                'dns-servers': list(v6subnets.values())[0]['dns_nameservers']}
             if 'interface_mtu' in mapping:
                 mapping_dict['dhcp6']['interface-mtu'] = mapping[
                     'interface_mtu']
@@ -625,7 +626,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             return (val and '/' in val[0]) and val[0] or None
 
         self.ext_seg_next_hop = {}
-        for es_name, es_info in es_cfg.iteritems():
+        for es_name, es_info in es_cfg.items():
             nh = ExtSegNextHopInfo(es_name)
             nh.from_config = True
             for key, value in es_info:
@@ -727,7 +728,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         return es
 
     def _alloc_int_fip(self, ip_ver, port_id, port_mac, es, ip):
-        fip = self.int_fip_pool[ip_ver].__iter__().next()
+        fip = next(self.int_fip_pool[ip_ver].__iter__())
         self.int_fip_pool[ip_ver].remove(fip)
         self.int_fip_alloc[ip_ver].setdefault(
             (port_id, port_mac), {}).setdefault(es, {})[ip] = fip
@@ -779,7 +780,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             es_list = self.es_port_dict.keys()
         else:
             es_list = ess
-        for es in es_list:
+        for es in list(es_list):
             if es not in self.es_port_dict:
                 continue
             if port_mac:

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -101,7 +101,7 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
             with excutils.save_and_reraise_exception():
                 # The upper layers will trigger the resync
                 LOG.error("Configuration failed on port manager: %s",
-                          e.message)
+                          str(e))
                 # Newer responses take precedence over old ones.
                 response_by_device_id_copy.update(self.response_by_device_id)
                 self.response_by_device_id = response_by_device_id_copy
@@ -112,7 +112,7 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
         device_ids = set(device_ids or [])
         LOG.debug('Update initially scheduled for port ids %s', device_ids)
         # See if more ports need to be updated due to request timeout
-        for request in self.pending_requests.get_requests():
+        for request in list(self.pending_requests.get_requests()):
             if current_time - request['timestamp'] > self.request_timeout:
                 LOG.info('Request %s has timed out, rescheduling',
                          request['request_id'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,pep8
+envlist = py27,py33,py36,pep8
 minversion = 1.6
 skipsdist = True
 


### PR DESCRIPTION
This patch aims at supporting 'python-opflex-agent' repo with python3.6 compatibility.

1. Deprecation and removal of `with contextlib.nested` for "mocks" issue is fixed by using literally nested `mock.patch`.

2. By mocking `os.path.basename` fixed the issue in mocking `sys.argv` in py36.

3. Fixed common py2 <-> py3 compatibility errors: 

- Replacing `dict.iteritems()` with `dict.items()`.

- Using `open()` instead of `file()`.

- Using `list` when python dict size changes.

- Removal of `Exception.message` in python3
