### PR TITLE
Modify EP file field name to indicate SVI and vlan type net

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1094,17 +1094,18 @@ class TestEndpointFileManager(base.OpflexTestBase):
         # the SVI related info we expect to see
         # on get_gbp_details
         port = self._port()
-        svi_info = {}
-        svi_info['svi'] = True
-        svi_info['endpoint_group_name'] = 'svi-net-id'
+        provider_vlan_info = {}
+        provider_vlan_info['vlan_only_or_svi'] = True
+        provider_vlan_info['endpoint_group_name'] = 'net-id'
 
-        mapping = self._get_gbp_details(**svi_info)
+        mapping = self._get_gbp_details(**provider_vlan_info)
         port.segmentation_id = 1234
         self.manager.declare_endpoint(port, mapping)
         epargs = self.manager._write_endpoint_file.call_args_list
 
-        self.assertEqual(svi_info['svi'], epargs[1][0][1].get('ext-svi'))
+        self.assertEqual(provider_vlan_info['vlan_only_or_svi'],
+            epargs[1][0][1].get('provider-vlan'))
         self.assertEqual(port.segmentation_id,
             epargs[1][0][1].get('ext-encap-id'))
-        self.assertEqual(svi_info['endpoint_group_name'],
+        self.assertEqual(provider_vlan_info['endpoint_group_name'],
             epargs[1][0][1].get('endpoint-group-name'))

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -323,14 +323,14 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             'neutron-metadata-optimization':
                 mapping['enable_metadata_optimization'],
         }
-        if mapping.get('svi'):
+        if mapping.get('vlan_only_or_svi'):
             # VM on SVI type network, in addition to the flag and
             # vlan-id, epg is set to a unique id so using the network
             # id provided in this field in the response to gbp details.
             mapping_dict['endpoint-group-name'] = (
                 mapping['endpoint_group_name'])
             mapping_dict['eg-mapping-alias'] = None
-            mapping_dict['ext-svi'] = True
+            mapping_dict['provider-vlan'] = True
             mapping_dict['ext-encap-id'] = port.segmentation_id
         else:
             mapping_dict['endpoint-group-name'] = (


### PR DESCRIPTION
Since the workflow for provider vlan nets is identical to SVI nets,
change the field from 'ext-svi' to 'provider-vlan' for clarity.