### PR TITLE
Updates to handling for EP file with VMs on VLAN (non SVI) nets

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -30,6 +30,10 @@ gbp_opts = [
                 default=['*'],
                 help=_("List of the physical networks managed by this agent. "
                        "Use * for binding any opflex network to this agent")),
+    cfg.ListOpt('vlan_networks',
+                default=['*'],
+                help=_("List of the physical networks managed by this agent. "
+                       "Use * for binding any vlan network to this agent")),
     cfg.ListOpt('internal_floating_ip_pool',
                default=['169.254.0.0/16'],
                help=_("IP pool used for intermediate floating-IPs with SNAT")),

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -325,6 +325,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             'neutron-metadata-optimization':
                 mapping['enable_metadata_optimization'],
         }
+        if port.network_type == n_constants.TYPE_VLAN:
+            mapping_dict['provider-vlan'] = True
+            mapping_dict['ext-encap-id'] = port.segmentation_id
         if mapping.get('svi'):
             # VM on SVI type network, in addition to the flag and
             # vlan-id, epg is set to a unique id so using the network
@@ -332,8 +335,6 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             mapping_dict['endpoint-group-name'] = (
                 mapping['endpoint_group_name'])
             mapping_dict['eg-mapping-alias'] = None
-            mapping_dict['ext-svi'] = True
-            mapping_dict['ext-encap-id'] = port.segmentation_id
         else:
             mapping_dict['endpoint-group-name'] = (
                 mapping['app_profile_name'] + "|" +


### PR DESCRIPTION
- Support VLAN (non SVI) nets.
- Similar to SVI except on how EPG name is handled. For SVI,
  it is overloaded with a unique id as received on the RPC.
  With the VLAN (non SVI) case the actual EPG name is used.
- Added config option to track physnet mappings for VLAN type
  nets.
- Some cosmetic changes to fields for better readability.