### PR TITLE
Set metadata and dhcp optimization to False for vlan type nets

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1102,7 +1102,13 @@ class TestEndpointFileManager(base.OpflexTestBase):
         if svi:
             vlan_info['svi'] = True
         vlan_info['endpoint_group_name'] = 'svi-net-id'
-
+        vlan_info['enable_dhcp_optimization'] = True
+        vlan_info['subnets'] = [{'id': 'id1',
+                                 'enable_dhcp': True,
+                                 'ip_version': 4,
+                                 'dns_nameservers': [],
+                                 'cidr': '192.168.0.0/24',
+                                 'host_routes': []}]
         mapping = self._get_gbp_details(**vlan_info)
         port.segmentation_id = 1234
         port.network_type = 'vlan'
@@ -1118,6 +1124,10 @@ class TestEndpointFileManager(base.OpflexTestBase):
             self.assertEqual((mapping['app_profile_name'] + '|' +
                 vlan_info['endpoint_group_name']),
                 epargs[1][0][1].get('endpoint-group-name'))
+
+        self.assertEqual(False,
+            epargs[1][0][1].get('neutron-metadata-optimization'))
+        self.assertEqual(None, epargs[1][0][1].get('dhcp4'))
 
     def test_vlan_net_no_svi_port_bound(self):
         self._test_vlan_net_port_bound()

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -164,6 +164,10 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     # Store for future processing
                     mac_aap_map.setdefault(
                         aap['mac_address'], []).append(aap)
+            # Metadata optimization always set to false for vlan type nets.
+            if port.network_type == n_constants.TYPE_VLAN:
+                mapping_copy['enable_metadata_optimization'] = False
+                mapping_copy['enable_dhcp_optimization'] = False
             # Create mapping file for base MAC address
             LOG.debug("Main file mapping %s", mapping_copy)
             macs.add(mapping_copy.get('mac_address') or port.vif_mac)
@@ -173,7 +177,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             mapping_copy['fixed_ips'] = []
             mapping_copy['subnets'] = []
             mapping_copy['enable_dhcp_optimization'] = False
-            mapping_copy['enable_metadata_optimization'] = True
+            mapping_copy['enable_metadata_optimization'] = (False
+                if port.network_type == n_constants.TYPE_VLAN else True)
             mapping_copy['promiscuous_mode'] = False
             # Map to file based on the AAP with a MAC address
             for mac, aaps in mac_aap_map.items():


### PR DESCRIPTION
The service file on opflex agent hosts triggers the creation of flows for the
optimized path. For VM's on vlan type nets we disable the optimized path.
Also added a fix to allow the co-existence a VM on a vlan type net (without
the optimized path) and a VM on a opflex type net (with the optimized path).

(cherry picked from commit 25b62690714db4fb4e3b8952a12b00c408ecf255)