### PR TITLE
Minor fix to 'dict' object has no attribute 'iteritems' in Py3.

### DIFF
--- a/opflexagent/type_opflex.py
+++ b/opflexagent/type_opflex.py
@@ -52,7 +52,7 @@ class OpflexTypeDriver(helpers.BaseTypeDriver):
             msg = _("physical_network required for opflex provider network")
             raise exc.InvalidInput(error_message=msg)
 
-        for key, value in segment.iteritems():
+        for key, value in segment.items():
             if value and key not in [api.NETWORK_TYPE,
                                      api.PHYSICAL_NETWORK,
                                      api.MTU]:


### PR DESCRIPTION
Some testcases are failing in group-based-policy due to:
'dict' object has no attribute 'iteritems'

To support Py3 in group-based-policy, this minor fix is needed.

Changing `dict.iteritems()` to `dict.items()`