### PR TITLE
Add new paramnter for nested mode

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -317,6 +317,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                    "interface-name": 'qpi',
                    "mac": 'aa:bb:cc:00:11:22',
                    "access-interface-vlan": 4094,
+                   "access-allow-untagged": True,
                    "promiscuous-mode": mapping['promiscuous_mode'],
                    "uuid": port.vif_id + '|aa-bb-cc-00-11-22',
                    "attributes": {'vm-name': 'somename'},

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -469,6 +469,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             allowed_vlans.extend(mapping['nested_domain_allowed_vlans'])
         if 'nested_host_vlan' in mapping and mapping['nested_host_vlan']:
             mapping_dict['access-interface-vlan'] = mapping['nested_host_vlan']
+            mapping_dict['access-allow-untagged'] = True
         if allowed_vlans:
             nested_domain_dict['trunk-vlans'] = self._list_to_range(
                     allowed_vlans)


### PR DESCRIPTION
The opflex-agent requires a new parameter when using nested mode,
so that it knows that it should apply a datapath optimization
behavior for the access port. A new parameter is introduced for
this: access-allow-untagged. It is a boolean, with a default
value of False (i.e. if not present, implied valiue of False).

(cherry picked from commit b4e23836e47187a8530c6eb0f739a785c206513a)