### PR TITLE
Handle generation of EP file for DHCP endpoint for SVI type nets

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -355,12 +355,20 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         virtual_ips = []
         if port.device_owner == n_constants.DEVICE_OWNER_DHCP:
             # vm-name, if specified in mappings, will override this
-            mapping_dict['attributes'] = {'vm-name': (
-                'dhcp|' +
-                mapping['ptg_tenant'] + '|' +
-                mapping['app_profile_name'] + '|' +
-                mapping['endpoint_group_name'])
-            }
+            if mapping.get('svi'):
+                # On svi nets, ptg_tenant, app_profile_name - N/A,
+                # only contains a fake epg name which is the net-id.
+                mapping_dict['attributes'] = {'vm-name': (
+                    'dhcp|' +
+                    mapping['endpoint_group_name'])
+                }
+            else:
+                mapping_dict['attributes'] = {'vm-name': (
+                    'dhcp|' +
+                    mapping['ptg_tenant'] + '|' +
+                    mapping['app_profile_name'] + '|' +
+                    mapping['endpoint_group_name'])
+                }
         else:
             if (mapping.get('enable_dhcp_optimization', False) and
                'subnets' in mapping):


### PR DESCRIPTION
Since SVI type nets are not associated with an EPG and use a fake EPG
as the neutron net-id - handle the missing fields for the DHCP endpoint's
EP file generation.

(cherry picked from commit 9411575f63cede777531933d0dad12ad53f449ec)