### PR TITLE
Fix SNAT conntrack logging cleanup

### DIFF
--- a/opflexagent/opflex_conn_track.py
+++ b/opflexagent/opflex_conn_track.py
@@ -11,8 +11,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import signal
 import subprocess
 import sys
+import time
 
 from neutron.common import config
 from neutron.common import utils as comm_utils
@@ -22,16 +24,77 @@ from oslo_log import log
 LOG = log.getLogger(__name__)
 
 
-def sh(cmd):
-    LOG.debug("conn_track: Running command: %s" % cmd)
-    ret = ''
-    try:
-        ret = subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, shell=True)
-    except Exception as e:
-        LOG.error("In running command: %s: %s" % (cmd, str(e)))
-    LOG.debug("conn_track: Command output: %s" % ret)
-    return ret
+class SnatConntrackLogger(object):
+    """Opflex SNAT Connection Tracking Logger
+
+    This class dumps the output of connection tracking events
+    for a Linux network namespace used to perform SNAT on hosts
+    running the neutron-opflex-agent. This class is created in
+    order to spawn two processes per namespace: one to run a
+    connection tracker in the Linux network namespace, and the
+    other to collect the standard output and dump it into syslog,
+    using the log level and facility set in a configuration file.
+    The process for this is managed using supervisord, which in
+    version 4.0 or later supports redirecting stdout and stderr
+    to syslog. However, older Linux distributions ship with
+    supervisord versions older than this, so the logger tool
+    must be used for this redirection. While supervisord can
+    handle the lifecycle of the top level process, this class
+    neededs manage the lifecycle of the child prcoesses that
+    are spawned (i.e. conntrack and logger), ensuring that
+    the parent exit code is set correctly so that supervisord
+    can handle any respawning, if needed.
+
+    REVISIT: Should have some sort of pooling to avoid exhaustion
+    """
+    def __init__(self, conntrack_cmd, logger_cmd):
+        self.ret = None
+        self.p1 = self.p2 = None
+        try:
+            # Conntrack process redirects stderr to stdout,
+            # returned Popen has file object for stdout
+            self.p1 = subprocess.Popen(
+                conntrack_cmd, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, close_fds=True, shell=True)
+            # Logger uses stdout member from conntrack process for its stdin
+            self.p2 = subprocess.Popen(
+                logger_cmd, stdin=self.p1.stdout, close_fds=True, shell=True)
+        except Exception as e:
+            LOG.error("In running commands: %s: %s" %
+                      (conntrack_cmd + logger_cmd, str(e)))
+
+    def _kill_child_procs(self):
+        for proc in [self.p1, self.p2]:
+            LOG.debug("conn_track: proc: %s" % proc.returncode)
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+
+    def terminate(self, signum, frame):
+        self._kill_child_procs()
+        LOG.debug("conn_track: returning %s" % -signum)
+        sys.exit(-signum)
+
+    def wait(self):
+        # REVISIT: We probably should consider whether we
+        #          should be checking for other signals,
+        #          such as SIGPIPE. The assumption is that
+        #          anything uncaught could result in a child
+        #          process not getting terminated, and left
+        #          as a zombie process
+        signal.signal(signal.SIGINT, self.terminate)
+        signal.signal(signal.SIGTERM, self.terminate)
+        while (self.p1 and self.p2) and (self.p1.poll() is None and
+                                         self.p2.poll() is None):
+            time.sleep(1)
+
+        self._kill_child_procs()
+        # NOTE: The assumption here is that this process is always
+        #       being managed by supervisord. In this case, we always
+        #       return a non-zero RC, as we want supervisord to restart
+        #       us whenever we die, regardless of the reason.
+        return -signal.SIGTERM
 
 
 # This program takes 3 parameters,
@@ -41,12 +104,16 @@ def sh(cmd):
 def main():
     config.setup_logging()
     comm_utils.log_opt_values(LOG)
-    command = ("ip netns exec %s conntrack -E -o timestamp 2>&1 | logger "
-               "-p %s.%s -t opflex-conn-track") % (
-                   sys.argv[1], sys.argv[2], sys.argv[3])
-    LOG.debug("conn_track command: %s" % command)
-    return sh(command)
+    cmd1 = ("ip netns exec %s conntrack -E -o timestamp") % (sys.argv[1])
+    cmd2 = ("logger -p %s.%s -t opflex-conn-track") % (sys.argv[2],
+                                                       sys.argv[3])
+    LOG.debug("conn_track command: %s" % cmd1)
+    LOG.debug("logger command: %s" % cmd2)
+    wrapper = SnatConntrackLogger(cmd1, cmd2)
+    return wrapper.wait()
 
 
 if __name__ == "__main__":
-    main()
+    ret = main()
+    LOG.debug("conn_track: returning %s" % ret)
+    sys.exit(ret)


### PR DESCRIPTION
The current logging for connection tracker events for the SNAT
linux namespaces does not get cleaned up correctly in all cases.
One of the problems was that two processes were spawned in the
same shell command, leaving one process untrackable. This patch
usees the Popen method of subprocess in order to explicitly spawn
and track both child processes, and adds a parent class to manage
the cleanup and return codes in all cases, in order to allow the
supervisord to restart dead processes when needed.

(cherry picked from commit 6df32ed39342c5d99a0a372477535bb72d2c9579)
(cherry picked from commit 0bcb653c405cad6a4eaf672abb1fe76875ea33cb)
(cherry picked from commit 946e4a86594a2a2ab624084b04b56360e92f812e)
(cherry picked from commit c25cabfc8a0b45b9bd2430b84858c98b7c088cd1)