### PR TITLE
Cleanup Queens

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${OS_TEST_PATH:-./opflexagent/test}
+top_dir=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 
-
 matrix:
   include:
     - python: 2.7
@@ -9,15 +8,12 @@ matrix:
     - python: 2.7
       env:
         - TOX_ENV=pep8
-    - python: 3.6
+    - python: 3.5
       env:
-        - TOX_ENV=py36
-    - python: 3.6
-      env:
-        - TOX_ENV=pep8
+        - TOX_ENV=py35
+
 install:
   - pip install tox
-
 
 script:
   - tox -e $TOX_ENV

--- a/opflexagent/_i18n.py
+++ b/opflexagent/_i18n.py
@@ -1,0 +1,20 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import oslo_i18n
+
+_translators = oslo_i18n.TranslatorFactory(domain='python_opflex_agent')
+
+# The translation function using the well-known name "_"
+_ = _translators.primary

--- a/opflexagent/apic_topology.py
+++ b/opflexagent/apic_topology.py
@@ -17,8 +17,8 @@ import re
 import sys
 
 import eventlet
+eventlet.monkey_patch()  # noqa
 
-eventlet.monkey_patch()
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_service import periodic_task
@@ -32,6 +32,7 @@ from neutron import manager
 from neutron import service
 from neutron_lib.utils import net as net_utils
 
+from opflexagent._i18n import _
 from opflexagent import constants
 from opflexagent import host_agent_rpc as arpc
 

--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -29,6 +29,7 @@ from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
+from opflexagent._i18n import _
 from opflexagent.utils import utils as opflexagent_utils
 from oslo_config import cfg
 from oslo_log import log as logging

--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -12,6 +12,8 @@
 
 from oslo_config import cfg
 
+from opflexagent._i18n import _
+
 
 gbp_opts = [
     cfg.StrOpt('epg_mapping_dir',

--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -26,6 +26,8 @@ from neutron.common import utils
 from neutron import wsgi
 from oslo_serialization import jsonutils
 
+from opflexagent._i18n import _
+
 LOG = logging.getLogger(__name__)
 
 

--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -11,7 +11,7 @@
 #    under the License.
 
 from neutron.common import rpc as n_rpc
-from neutron.common import topics
+from neutron_lib.agent import topics
 from oslo_log import helpers as log
 from oslo_log import log as logging
 import oslo_messaging

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -133,20 +133,20 @@ class SnatIptablesManager(object):
         if_dev = self._add_port_and_netns(next_hop_if, ns,
                                           if_mac=next_hop_mac, mtu=mtu)
         next_hop_mac = if_dev.link.address
-        LOG.debug(_("Created namespace %(ns)s, and added port %(pt)s to it"),
+        LOG.debug("Created namespace %(ns)s, and added port %(pt)s to it",
                   {'ns': ns, 'pt': next_hop_if})
 
         if use_v4:
             self._setup_routes(if_dev, 4, ip_start, ip_end, ip_gw)
-            LOG.debug(_("Set IPv4 address and routes"))
+            LOG.debug("Set IPv4 address and routes")
 
         if use_v6:
             self._setup_routes(if_dev, 6, ip6_start, ip6_end, ip6_gw)
-            LOG.debug(_("Set IPv6 address and routes"))
+            LOG.debug("Set IPv6 address and routes")
 
         self._setup_iptables(ns, next_hop_if, ip_start, ip_end,
                              ip6_start, ip6_end)
-        LOG.debug(_("Installed iptables rules"))
+        LOG.debug("Installed iptables rules")
         return (next_hop_if, next_hop_mac)
 
     def cleanup_snat_for_es(self, es_name, next_hop_if=None):

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -13,8 +13,8 @@
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent.utils.port_managers import async_port_manager

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -16,8 +16,8 @@ import sys
 
 import mock
 from mock import call
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -14,8 +14,8 @@ import shutil
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager
@@ -412,8 +412,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         trunk_details['subports'] = subports
         port.trunk_details = trunk_details
 
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.assertFalse(self.agent.bridge_manager.add_patch_ports.called)
         self.assertFalse(self.agent.bridge_manager.delete_patch_ports.called)
 

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -14,10 +14,10 @@ import shutil
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
-sys.modules['opflexagent.vpplib'] = mock.MagicMock()
-sys.modules['opflexagent.vpplib.VPPApi'] = mock.MagicMock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
+sys.modules['opflexagent.vpplib'] = mock.MagicMock()  # noqa
+sys.modules['opflexagent.vpplib.VPPApi'] = mock.MagicMock()  # noqa
 
 from neutron.api.rpc.callbacks import events
 from neutron.conf.agent import dhcp as dhcp_config
@@ -393,8 +393,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 port_id=uuidutils.generate_uuid(), trunk_id=trunk_id,
                 segmentation_type='foo', segmentation_id=i)
             for i in range(2)]
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.assertFalse(self.agent.bridge_manager.add_patch_ports.called)
         self.assertFalse(self.agent.bridge_manager.delete_patch_ports.called)
         self.agent.bridge_manager.managed_trunks[trunk_id] = 'master_port'
@@ -406,8 +408,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.agent.bridge_manager.trunk_rpc.update_subport_bindings = (
             binding_call)
 
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.agent.bridge_manager.add_patch_ports.assert_called_with(
             [subports[0].port_id, subports[1].port_id],
             attached_macs={subports[0].port_id: '0', subports[1].port_id: '1'})

--- a/opflexagent/test/test_ovs_manager.py
+++ b/opflexagent/test/test_ovs_manager.py
@@ -14,8 +14,8 @@ import contextlib
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent.utils.bridge_managers import ovs_manager
 

--- a/opflexagent/test/test_rpc.py
+++ b/opflexagent/test/test_rpc.py
@@ -13,8 +13,8 @@
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import rpc
 from opflexagent.test import base

--- a/opflexagent/type_opflex.py
+++ b/opflexagent/type_opflex.py
@@ -16,6 +16,7 @@ from neutron_lib.plugins.ml2 import api
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from opflexagent._i18n import _
 from opflexagent import constants
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ cfg.CONF.register_opts(flat_opts, "ml2_type_opflex")
 class OpflexTypeDriver(helpers.BaseTypeDriver):
 
     def __init__(self):
-        LOG.info(_("ML2 OpflexTypeDriver initialization complete"))
+        LOG.info("ML2 OpflexTypeDriver initialization complete")
         self.default_opflex_network = (cfg.CONF.ml2_type_opflex.
                                        default_opflex_network)
         super(OpflexTypeDriver, self).__init__()

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -13,6 +13,7 @@
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib import constants as n_constants
 from neutron_lib.utils import helpers
+from opflexagent._i18n import _
 from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import ovs_lib

--- a/opflexagent/utils/bridge_managers/trunk_skeleton.py
+++ b/opflexagent/utils/bridge_managers/trunk_skeleton.py
@@ -30,7 +30,7 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
         super(OpflexTrunkMixin, self).__init__()
         self.managed_trunks = {}
         registry.unsubscribe(self.handle_trunks, resources.TRUNK)
-        registry.subscribe(self.handle_subports, resources.SUBPORT)
+        registry.register(self.handle_subports, resources.SUBPORT)
         self._context = n_context.get_admin_context_without_session()
         self.trunk_rpc = agent.TrunkStub()
 
@@ -39,10 +39,11 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
         self._context.request_id = o_context.generate_request_id()
         return self._context
 
-    def handle_trunks(self, trunks, event_type):
+    def handle_trunks(self, context, resource_type, trunks, event_type):
         pass
 
-    def handle_subports(self, subports, event_type, trunk_id=None):
+    def handle_subports(self, context, resource_type, subports, event_type,
+                        trunk_id=None):
         LOG.info("Handling subports %s event %s" % (subports, event_type))
         if subports:
             trunk_id = trunk_id or subports[0].trunk_id
@@ -107,8 +108,9 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
                         segmentation_type=x['segmentation_type'],
                         segmentation_id=x['segmentation_id'])
                     for x in port.trunk_details['subports']]
-                self.handle_subports(subports, events.CREATED,
-                                     trunk_id=trunk_id)
+                self.handle_subports(
+                    self.context, None, subports, events.CREATED,
+                    trunk_id=trunk_id)
             self.trunk_rpc.update_trunk_status(self.context, trunk_id,
                                                constants.ACTIVE_STATUS)
 

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -211,8 +211,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             self._registered_endpoints.add(port.vif_id)
             self.vif_int_dict.update({port.vif_id: port.port_name})
         except Exception as e:
-            LOG.exception(_("Error while parsing ep file for "
-                            "port %(port)s: %(ex)s"), {'port': port, 'ex': e})
+            LOG.exception("Error while parsing ep file for "
+                          "port %(port)s: %(ex)s", {'port': port, 'ex': e})
 
     def undeclare_endpoint(self, port_id):
         LOG.info("Endpoint undeclare requested for port %s", port_id)
@@ -270,8 +270,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                                 # KeyError should only happen for UT
                                 # EP File would be deleted if parsing fails
                                 # for a VPP endpoint at restart
-                                LOG.exception(_("Error while parsing ep "
-                                    "file %(file)s: %(ex)s"),
+                                LOG.exception("Error while parsing ep "
+                                    "file %(file)s: %(ex)s",
                                     {'file': f, 'ex': e})
 
                     else:
@@ -554,7 +554,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
     def _handle_host_snat_ip(self, host_snat_ips):
         for hsi in host_snat_ips:
-            LOG.debug(_("Auto-allocated host SNAT IP: %s"), hsi)
+            LOG.debug("Auto-allocated host SNAT IP: %s", hsi)
             es = hsi.get('external_segment_name')
             if not es:
                 continue
@@ -576,13 +576,13 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     nh.ip6_gateway = gw
                     updated = True
             else:
-                LOG.info(_("Ignoring invalid auto-allocated SNAT IP %s"), ip)
+                LOG.info("Ignoring invalid auto-allocated SNAT IP %s", ip)
             if updated:
                 # Clear the interface so that SNAT iptables will be
                 # re-created as required; leave MAC as is so that it will
                 # be re-used
                 nh.next_hop_iface = None
-                LOG.info(_("Add/update SNAT info: %s"), nh)
+                LOG.info("Add/update SNAT info: %s", nh)
 
     def _map_dhcp_info(self, fixed_ips, mapping, mapping_dict):
         """ Add DHCP specific info to the EP file."""
@@ -658,7 +658,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 elif key == 'ip6_gateway':
                     nh.ip6_gateway = parse_gateway(value)
             self.ext_seg_next_hop[es_name] = nh
-            LOG.debug(_("Found external segment: %s") % nh)
+            LOG.debug("Found external segment: %s" % nh)
 
     def _fill_ip_mapping_info(self, port_id, port_mac, gbp_details, ips,
                               mapping):
@@ -751,9 +751,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         self.int_fip_pool[ip_ver].remove(fip)
         self.int_fip_alloc[ip_ver].setdefault(
             (port_id, port_mac), {}).setdefault(es, {})[ip] = fip
-        LOG.debug(_("Allocated internal v%(version)d FIP %(fip)s to "
-                    "port %(port)s, %(mac)s, fixed IP %(ip)s "
-                    "in external segment %(es)s"),
+        LOG.debug("Allocated internal v%(version)d FIP %(fip)s to "
+                  "port %(port)s, %(mac)s, fixed IP %(ip)s "
+                  "in external segment %(es)s",
                   {'fip': fip, 'port': port_id, 'mac': port_mac,
                    'es': es, 'ip': ip, 'version': ip_ver})
         return fip
@@ -783,9 +783,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 fips.extend(x.values())
         for float_ip in fips:
             self.int_fip_pool[ip_ver].add(float_ip)
-        LOG.debug(_("Released internal v%(version)d FIP(s) %(fip)s "
-                    "for port %(port)s, mac %(mac)s, "
-                    "fixed IP %(ip)s, external segment %(es)s"),
+        LOG.debug("Released internal v%(version)d FIP(s) %(fip)s "
+                  "for port %(port)s, mac %(mac)s, "
+                  "fixed IP %(ip)s, external segment %(es)s",
                   {'fip': fips, 'port': port_id, 'mac': port_mac or '<all>',
                    'es': es or '<all>', 'ip': ip or '<all>',
                    'version': ip_ver})
@@ -819,8 +819,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 self.snat_iptables.cleanup_snat_for_es(es)
                 LOG.debug("Removed SNAT iptables for %s", es)
             except Exception as e:
-                LOG.warn(_("Failed to remove SNAT iptables for "
-                           "%(es)s: %(ex)s"),
+                LOG.warn("Failed to remove SNAT iptables for "
+                         "%(es)s: %(ex)s",
                          {'es': es, 'ex': e})
 
     def _get_next_hop_info_for_es(self, ipm, host_snat_ip_es):
@@ -840,13 +840,13 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                         nh.ip_start, nh.ip_end, nh.ip_gateway,
                         nh.ip6_start, nh.ip6_end, nh.ip6_gateway,
                         nh.next_hop_mac, mtu=self.nat_mtu_size))
-                LOG.info(_("Created SNAT iptables for %(es)s: "
-                           "iface %(if)s, mac %(mac)s"),
+                LOG.info("Created SNAT iptables for %(es)s: "
+                         "iface %(if)s, mac %(mac)s",
                          {'es': es_name, 'if': nh.next_hop_iface,
                           'mac': nh.next_hop_mac})
             except Exception as e:
-                LOG.exception(_("Error while creating SNAT iptables for "
-                                "%(es)s: %(ex)s"),
+                LOG.exception("Error while creating SNAT iptables for "
+                              "%(es)s: %(ex)s",
                               {'es': es_name, 'ex': e})
             self._create_host_endpoint_file(ipm, nh)
         return (nh.next_hop_iface, nh.next_hop_mac)

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -13,7 +13,7 @@
 import time
 
 from neutron.agent import rpc as agent_rpc
-from neutron.common import topics
+from neutron_lib.agent import topics
 from neutron_lib import context
 from oslo_log import log as logging
 from oslo_utils import excutils

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -31,7 +31,7 @@ def get_bridge_manager(conf):
                 bridge_manager.BRIDGE_MANAGER_NAMESPACE, conf.bridge_manager)
         return loaded_class()
     except ImportError:
-        LOG.error(_("Error loading bridge manager '%s'"),
+        LOG.error("Error loading bridge manager '%s'",
                   conf.bridge_manager)
         raise SystemExit(1)
 

--- a/opflexagent/vif_plug_vpp/exception.py
+++ b/opflexagent/vif_plug_vpp/exception.py
@@ -10,9 +10,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from os_vif.i18n import _
-
 from os_vif import exception as osv_exception
+
+from opflexagent._i18n import _
 
 
 class AgentError(osv_exception.ExceptionBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,5 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-oslo.serialization>=2.18.0,!=2.19.1  # Apache-2.0
-oslo.utils>=3.33.0  # Apache-2.0
-oslo.i18n>=3.15.3  # Apache-2.0
-oslo.log>=3.36.0  # Apache-2.0
-oslo.config>=5.1.0  # Apache-2.0
-os-vif>=1.7.0,!=1.8.0  # Apache-2.0
-
+os-vif!=1.8.0,>=1.7.0 # Apache-2.0
 pyinotify

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,22 +2,12 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0  # PSF/ZPL
--e git+https://github.com/openstack/neutron.git@stable/queens#egg=neutron
-hacking<0.11,>=0.10.0
-
-cliff>=2.8.0  # Apache-2.0
-coverage>=4.0,!=4.4  # Apache-2.0
-fixtures>=3.0.0 # Apache-2.0/BSD
-httplib2>=0.7.5
-mock>=2.0 # BSD
-ordereddict
-python-subunit>=0.0.18 # Apache-2.0/BSD
-requests-mock>=1.1 # Apache-2.0
-sphinx>=1.6.2  # BSD
-testrepository>=0.0.18 # Apache-2.0/BSD
-testresources>=0.2.4 # Apache-2.0/BSD
+-e git+https://opendev.org/openstack/neutron.git@stable/queens#egg=neutron
+hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+coverage!=4.4,>=4.0 # Apache-2.0
+testtools>=2.2.0 # MIT
+testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
-testtools>=1.4.0 # MIT
-WebTest>=2.0 # MIT
-oslotest>=1.10.0 # Apache-2.0
+WebTest>=2.0.27 # MIT
+oslotest>=3.2.0 # Apache-2.0
+stestr>=1.0.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,43 @@
 [tox]
-envlist = py27,py33,py36,pep8
-minversion = 1.6
+envlist = py27,py35,pep8
+minversion = 3.4.0
 skipsdist = True
+
+# REVISIT: Requiring the tox-venv tox plugin seems to avoid
+# installation of the latest setuptools version, which is incompatible
+# the 1.0 version of MarkupSafe pinned by
+# https://releases.openstack.org/constraints/upper/queens. This should
+# be removed for rocky and newer, which use newer MarkupSafe versions
+# that have resolved the setuptools incompatibility.
+requires = tox-venv
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
+         OS_LOG_CAPTURE={env:OS_LOG_CAPTURE:true}
+         OS_STDOUT_CAPTURE={env:OS_STDOUT_CAPTURE:true}
+         OS_STDERR_CAPTURE={env:OS_STDERR_CAPTURE:true}
+         PYTHONWARNINGS=default::DeprecationWarning
+passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 usedevelop = True
 install_command =
-  pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/queens} {opts} {packages}
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-commands =
-  python setup.py testr --slowest --testr-args='{posargs}'
+  pip install {opts} {packages}
+deps =
+  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
+whitelist_externals = sh
+commands = stestr run {posargs}
 
 [testenv:hashtest]
 setenv = VIRTUAL_ENV={envdir}
 
 [testenv:pep8]
+basepython = python2.7
 commands =
   flake8
 
 [testenv:cover]
+basepython = python2.7
 commands =
   coverage erase
   coverage run -m testtools.run


### PR DESCRIPTION
Enhance compatabilty with newer Neutron branches while maintaining
compatability with stable/queens Neutron, and improve the build/test
process. Highlights include:

* Use definitions from neutron_lib where appropriate.

* Update imports of classes moved from
  neutron.agent.securitygroups_rpc to
  neutron.api.rpc.handlers.securitygroups_rpc.

* Replace RPC callback deprecated subscribe method with register.

* Don't use deprecated oslo_config.MultiConfigParser.

* Remove i18n translation markers from log messages, and update
  remaining ones to properly use oslo.i18n.

* Eliminate unneeded requirements and test-requirements, and update
  remaining ones to match upstream stable/queens Neutron.

* Use stestr instead of testr to run UTs.

* Specify basepython as python2.7 for pep8 and cover jobs, in case
  python3 version of tox is used.

* Require tox-venv to address incompatability between version 1.0 of
  MarkupSafe pinned by
  https://releases.openstack.org/constraints/upper/queens and recent
  versions of setuptools.