### PR TITLE
Add support for upstream Rocky release

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,8 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
--e git+https://opendev.org/openstack/neutron.git@stable/queens#egg=neutron
-hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+-e git+https://opendev.org/openstack/neutron.git@stable/rocky#egg=neutron
+hacking>=1.1.0,<1.2.0 # Apache-2.0
 coverage!=4.4,>=4.0 # Apache-2.0
 testtools>=2.2.0 # MIT
 testresources>=2.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,6 @@ envlist = py27,py35,pep8
 minversion = 3.4.0
 skipsdist = True
 
-# REVISIT: Requiring the tox-venv tox plugin seems to avoid
-# installation of the latest setuptools version, which is incompatible
-# the 1.0 version of MarkupSafe pinned by
-# https://releases.openstack.org/constraints/upper/queens. This should
-# be removed for rocky and newer, which use newer MarkupSafe versions
-# that have resolved the setuptools incompatibility.
-requires = tox-venv
-
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          OS_LOG_CAPTURE={env:OS_LOG_CAPTURE:true}
@@ -22,7 +14,7 @@ usedevelop = True
 install_command =
   pip install {opts} {packages}
 deps =
-  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
+  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/rocky}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
 whitelist_externals = sh


### PR DESCRIPTION
Depend on stable/rocky rather than stable/queens branch of upstream
Neutron repository. Changes needed for compatability with stable/rocky
that were also compatible with stable/queens were made in previous
patches, so only rocky-specific changes are included here.