### PR TITLE
Fix vlan_networks reporting

### DIFF
--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -88,7 +88,8 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             'binary': 'neutron-opflex-agent',
             'host': self.host,
             'topic': n_constants.L2_AGENT_TOPIC,
-            'configurations': {'opflex_networks': self.opflex_networks},
+            'configurations': {'opflex_networks': self.opflex_networks,
+                               'vlan_networks': self.vlan_networks},
             'start_flag': True}
 
         # Initialize OVS Manager


### PR DESCRIPTION
The vlan_networks parameter wasn't being populated in the agent's
reporting to the plugin. This prevents the mappings from being
considered when the plugin performs port binding.

(cherry picked from commit 2128307066e5571c80bb22f7f03415f5a04bc48d)