### PR TITLE
Cleanup Queens (part 2)

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -13,29 +13,30 @@
 import functools
 import hashlib
 import multiprocessing
-import netaddr
 import os
 import os.path
-import pyinotify
 import signal
-from six.moves import queue as Queue
 import subprocess
 import sys
 import time
 import uuid
+
+import netaddr
+import pyinotify
+from six.moves import queue as Queue
 
 from neutron.common import config as common_config
 from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
-from opflexagent._i18n import _
-from opflexagent.utils import utils as opflexagent_utils
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
+from opflexagent._i18n import _
 from opflexagent import config as oscfg  # noqa
+from opflexagent.utils import utils as opflexagent_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ def read_jsonfile(name):
         with open(name, "r") as f:
             retval = jsonutils.load(f)
     except Exception as e:
-        LOG.warn("Exception in reading file: %s" % str(e))
+        LOG.warn("Exception in reading file: %s", str(e))
     return retval
 
 
@@ -99,7 +100,7 @@ def write_jsonfile(name, data):
         with open(name, "w") as f:
             jsonutils.dump(data, f)
     except Exception as e:
-        LOG.warn("Exception in writing file: %s" % str(e))
+        LOG.warn("Exception in writing file: %s", str(e))
 
 
 class AddressPool(object):
@@ -128,13 +129,13 @@ class FileProcessor(object):
         self.processfn = processfn
 
     def scanfiles(self, files):
-        LOG.debug("FileProcessor: processing files: %s" % files)
+        LOG.debug("FileProcessor: processing files: %s", files)
         relevant_files = []
         for (action, filename) in files:
             if all(not filename.endswith(ext) for ext in self.extensions):
                 continue
             relevant_files.append((action, filename))
-        LOG.debug("FileProcessor: relevant files %s" % relevant_files)
+        LOG.debug("FileProcessor: relevant files %s", relevant_files)
         return self.processfn(relevant_files)
 
     def scan(self):
@@ -154,7 +155,7 @@ class FileProcessor(object):
                 event = self.eventq.get()
                 while event is not None:
                     # drain all events in queue and batch them
-                    LOG.debug("FileProcessor: event: %s" % event)
+                    LOG.debug("FileProcessor: event: %s", event)
                     if event == EOQ:
                         connected = False
                         event = None
@@ -176,7 +177,7 @@ class FileProcessor(object):
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            LOG.warn("FileProcessor: Exception: %s" % str(e))
+            LOG.warn("FileProcessor: Exception: %s", str(e))
         return
 
 
@@ -215,18 +216,19 @@ class FileWatcher(object):
             functools.partial(self.process))
         fprun = functools.partial(fp.run)
         self.processor = multiprocessing.Process(target=fprun)
-        LOG.debug("FileWatcher: %s: starting" % self.name)
+        LOG.debug("FileWatcher: %s: starting", self.name)
         self.processor.start()
 
     def action(self, event):
         # event.maskname, event.filename
-        LOG.debug("FileWatcher: %s: event: %s" % (self.name, event))
+        LOG.debug("FileWatcher: %(name)s: event: %(event)s",
+                  {'name': self.name, 'event': event})
         self.eventq.put(event)
 
     def process(self, files):
         # Override in child class
-        LOG.debug("FileWatcher: %s: process: %s" % (
-            self.name, files))
+        LOG.debug("FileWatcher: %(name)s: process: %(files)s",
+                  {'name': self.name, 'files': files})
 
     def terminate(self, signum, frame):
         self.eventq.put(EOQ)
@@ -242,13 +244,13 @@ class FileWatcher(object):
         notifier = pyinotify.Notifier(wm, handler)
         wm.add_watch(self.watchdir, handler.events, rec=False)
         try:
-            LOG.debug("FileWatcher: %s: notifier waiting ..." % self.name)
+            LOG.debug("FileWatcher: %s: notifier waiting ...", self.name)
             notifier.loop()
         finally:
-            LOG.debug("FileWatcher: %s: notifier returned" % self.name)
+            LOG.debug("FileWatcher: %s: notifier returned", self.name)
             self.terminate(None, None)
 
-        LOG.debug("FileWatcher: %s: processor returned" % self.name)
+        LOG.debug("FileWatcher: %s: processor returned", self.name)
         self.processor.join()
         return True
 
@@ -262,7 +264,7 @@ class TmpWatcher(FileWatcher):
             filedir, extensions, name="ep-watcher")
 
     def process(self, files):
-        LOG.debug("TmpWatcher files: %s" % files)
+        LOG.debug("TmpWatcher files: %s", files)
 
 
 class EpWatcher(FileWatcher):
@@ -315,7 +317,7 @@ class EpWatcher(FileWatcher):
         return fquuid
 
     def process(self, files):
-        LOG.debug("EP files: %s" % files)
+        LOG.debug("EP files: %s", files)
 
         curr_svc = read_jsonfile(self.svcfile)
         ip_pool = AddressPool(SVC_IP_BASE, SVC_IP_SIZE)
@@ -406,7 +408,7 @@ class StateWatcher(FileWatcher):
         super(StateWatcher, self).terminate(signum, frame)
 
     def process(self, files):
-        LOG.debug("State Event: %s" % files)
+        LOG.debug("State Event: %s", files)
 
         curr_alloc = read_jsonfile(self.svcfile)
 
@@ -440,16 +442,15 @@ class StateWatcher(FileWatcher):
         for idx in ["uuid", "domain-name", "domain-policy-space"]:
             if asvc[idx] != alloc[idx]:
                 return False
-        if asvc["service-mapping"][0]["next-hop-ip"] != \
-           alloc["next-hop-ip"]:
-                return False
+        if asvc["service-mapping"][0]["next-hop-ip"] != alloc["next-hop-ip"]:
+            return False
         return True
 
     def as_del(self, filename, asvc):
         try:
             self.mgr.del_ip(asvc["service-mapping"]["next-hop-ip"])
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in deleting IP: %s" %
+            LOG.warn("EPwatcher: Exception in deleting IP: %s",
                      str(e))
 
         proxyfilename = PROXY_FILE_NAME_FORMAT % asvc["uuid"]
@@ -458,7 +459,7 @@ class StateWatcher(FileWatcher):
             os.remove(filename)
             os.remove(proxyfilename)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in deleting file: %s" % str(e))
+            LOG.warn("EPwatcher: Exception in deleting file: %s", str(e))
 
     def as_create(self, alloc):
         asvc = {
@@ -479,7 +480,7 @@ class StateWatcher(FileWatcher):
         try:
             self.mgr.add_ip(alloc["next-hop-ip"])
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in adding IP: %s" %
+            LOG.warn("EPwatcher: Exception in adding IP: %s",
                      str(e))
 
         asfilename = AS_FILE_NAME_FORMAT % asvc["uuid"]
@@ -488,7 +489,7 @@ class StateWatcher(FileWatcher):
             with open(asfilename, "w") as f:
                 jsonutils.dump(asvc, f)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in writing services file: %s" %
+            LOG.warn("EPwatcher: Exception in writing services file: %s",
                      str(e))
 
         proxyfilename = PROXY_FILE_NAME_FORMAT % asvc["uuid"]
@@ -500,7 +501,7 @@ class StateWatcher(FileWatcher):
             pidfile = PID_FILE_NAME_FORMAT % asvc["uuid"]
             self.mgr.sh("rm -f %s" % pidfile)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in writing proxy file: %s" %
+            LOG.warn("EPwatcher: Exception in writing proxy file: %s",
                      str(e))
 
     def proxyconfig(self, alloc):
@@ -545,7 +546,7 @@ class SnatConnTrackHandler(object):
             self.mgr.sh("rm -f %s" % pidfile)
             self.mgr.update_supervisor()
         except Exception as e:
-            LOG.warn("ConnTrack: Exception in writing snat file: %s" %
+            LOG.warn("ConnTrack: Exception in writing snat file: %s",
                      str(e))
 
     def conn_track_del(self, netns):
@@ -555,7 +556,7 @@ class SnatConnTrackHandler(object):
             os.remove(snatfilename)
             self.mgr.update_supervisor()
         except Exception as e:
-            LOG.warn("ConnTrack: Exception in deleting file: %s" % str(e))
+            LOG.warn("ConnTrack: Exception in deleting file: %s", str(e))
 
     def conn_track_config(self, netns):
         snatstr = "\n".join([
@@ -597,8 +598,9 @@ class AsMetadataManager(object):
                 self.init_all()
                 self.initialized = True
             except Exception as e:
-                LOG.error("%s: in initializing anycast metadata service: %s" %
-                          (self.name, str(e)))
+                LOG.error("%(name)s: in initializing anycast metadata "
+                          "service: %(exc)s",
+                          {'name': self.name, 'exc': str(e)})
 
     def ensure_terminated(self):
         if self.initialized:
@@ -607,27 +609,29 @@ class AsMetadataManager(object):
                 self.clean_files()
                 self.stop_supervisor()
             except Exception as e:
-                LOG.error("%s: in shuttingdown anycast metadata service: %s" %
-                          (self.name, str(e)))
+                LOG.error("%(name)s: in shuttingdown anycast metadata "
+                          "service: %(exc)s",
+                          {'name': self.name, 'exc': str(e)})
 
     def sh(self, cmd, as_root=True):
         if as_root and self.root_helper:
             cmd = "%s %s" % (self.root_helper, cmd)
-        LOG.debug("%s: Running command: %s" % (
-            self.name, cmd))
+        LOG.debug("%(name)s: Running command: %(cmd)s",
+                  {'name': self.name, 'cmd': cmd})
         ret = ''
         try:
             ret = subprocess.check_output(
                 cmd, stderr=subprocess.STDOUT, shell=True)
         except Exception as e:
-            LOG.error("In running command: %s: %s" % (cmd, str(e)))
-        LOG.debug("%s: Command output: %s" % (
-            self.name, ret))
+            LOG.error("In running command: %(cmd)s: %(exc)s",
+                      {'cmd': cmd, 'exc': str(e)})
+        LOG.debug("%(name)s: Command output: %(ret)s",
+                  {'name': self.name, 'ret': ret})
         return ret
 
     def write_file(self, name, data):
-        LOG.debug("%s: Writing file: name=%s, data=%s" % (
-            self.name, name, data))
+        LOG.debug("%(name)s: Writing file: name=%(file)s, data=%(data)s",
+                  {'name': self.name, 'file': name, 'data': data})
         with open(name, "w") as f:
             f.write(data)
 

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -209,9 +209,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     (physical_network in self.opflex_networks)):
                 # Endpoint Manager to process the EP info
                 LOG.debug("Processing the endpoint mapping "
-                          "for port %(port)s: \n mapping: %(mapping)s" % {
-                              'port': port.vif_id,
-                              'mapping': port.gbp_details})
+                          "for port %(port)s: \n mapping: %(mapping)s",
+                          {'port': port.vif_id,
+                           'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
                 LOG.error("Cannot provision OPFLEX network for "
@@ -224,9 +224,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     (physical_network in self.vlan_networks)):
                 # Endpoint Manager to process the EP info
                 LOG.debug("Processing the endpoint mapping "
-                          "for port %(port)s: \n mapping: %(mapping)s" % {
-                              'port': port.vif_id,
-                              'mapping': port.gbp_details})
+                          "for port %(port)s: \n mapping: %(mapping)s",
+                          {'port': port.vif_id,
+                           'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
                 LOG.error("Cannot provision VLAN network for "
@@ -355,7 +355,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                         # No need to rerise, port could be bound somehow else
                         ctx.reraise = False
                         LOG.warn("Device %s not found while disabling mac "
-                                 "learning" % br_name)
+                                 "learning", br_name)
 
     def treat_devices_added_or_updated(self, details):
         """Process added or updated devices
@@ -380,8 +380,8 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 details.pop('port_id', None)
             if (gbp_details and gbp_details.get('host') and
                 gbp_details['host'] != self.host):
-                    self.port_unbound(device)
-                    return False
+                self.port_unbound(device)
+                return False
             elif neutron_details and 'port_id' in neutron_details:
                 LOG.info("Port %(device)s updated. Details: %(details)s",
                          {'device': device, 'details': details})

--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -74,14 +74,14 @@ class NetworkMetadataProxyHandler(object):
             with open(fqfn, "r") as f:
                 nets = jsonutils.load(f)
         except Exception as e:
-            LOG.warning("Exception in reading file: %s" % str(e))
+            LOG.warning("Exception in reading file: %s", str(e))
 
         if nets:
             if domain_id in nets:
                 if remote_address in nets[domain_id]:
                     return nets[domain_id][remote_address]
-        LOG.warning("IP address not found: domain=%s, addr=%s" % (
-                    domain_id, remote_address))
+        LOG.warning("IP address not found: domain=%(domain)s, addr=%(addr)s",
+                    {'domain': domain_id, 'addr': remote_address})
         return None
 
     def _proxy_request(self, remote_address, method, path_info,

--- a/opflexagent/opflex_conn_track.py
+++ b/opflexagent/opflex_conn_track.py
@@ -60,12 +60,12 @@ class SnatConntrackLogger(object):
             self.p2 = subprocess.Popen(
                 logger_cmd, stdin=self.p1.stdout, close_fds=True, shell=True)
         except Exception as e:
-            LOG.error("In running commands: %s: %s" %
-                      (conntrack_cmd + logger_cmd, str(e)))
+            LOG.error("In running commands: %(cmds)s: %(exc)s",
+                      {'cmds': conntrack_cmd + logger_cmd, 'exc': str(e)})
 
     def _kill_child_procs(self):
         for proc in [self.p1, self.p2]:
-            LOG.debug("conn_track: proc: %s" % proc.returncode)
+            LOG.debug("conn_track: proc: %s", proc.returncode)
             try:
                 proc.terminate()
             except Exception:
@@ -73,7 +73,7 @@ class SnatConntrackLogger(object):
 
     def terminate(self, signum, frame):
         self._kill_child_procs()
-        LOG.debug("conn_track: returning %s" % -signum)
+        LOG.debug("conn_track: returning %s", -signum)
         sys.exit(-signum)
 
     def wait(self):
@@ -107,13 +107,13 @@ def main():
     cmd1 = ("ip netns exec %s conntrack -E -o timestamp") % (sys.argv[1])
     cmd2 = ("logger -p %s.%s -t opflex-conn-track") % (sys.argv[2],
                                                        sys.argv[3])
-    LOG.debug("conn_track command: %s" % cmd1)
-    LOG.debug("logger command: %s" % cmd2)
+    LOG.debug("conn_track command: %s", cmd1)
+    LOG.debug("logger command: %s", cmd2)
     wrapper = SnatConntrackLogger(cmd1, cmd2)
     return wrapper.wait()
 
 
 if __name__ == "__main__":
     ret = main()
-    LOG.debug("conn_track: returning %s" % ret)
+    LOG.debug("conn_track: returning %s", ret)
     sys.exit(ret)

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -12,8 +12,8 @@
 
 
 import hashlib
-import netaddr
 
+import netaddr
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import iptables_manager
 from oslo_config import cfg

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -186,12 +186,12 @@ class TestAsyncPortManager(base.BaseTestCase):
 
     def test_apply_config_fails(self):
         self.agent.treat_devices_added_or_updated = mock.Mock(
-            side_effect=Exception)
+            side_effect=ValueError)
         to_schedule = set(['1', '2', '3', '4'])
         self.manager.schedule_update(to_schedule)
         update = self._get_device_requests(['1', '2', '4'])
         self.manager._opflex_endpoint_update(mock.Mock(), update)
-        self.assertRaises(Exception, self.manager.apply_config)
+        self.assertRaises(ValueError, self.manager.apply_config)
         # responses are restored after the exception
         self.assertEqual(3, len(self.manager.response_by_device_id))
 

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1151,7 +1151,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
 
         self.assertEqual(False,
             epargs[1][0][1].get('neutron-metadata-optimization'))
-        self.assertEqual(None, epargs[1][0][1].get('dhcp4'))
+        self.assertIsNone(epargs[1][0][1].get('dhcp4'))
 
     def test_vlan_net_no_svi_port_bound(self):
         self._test_vlan_net_port_bound()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -125,7 +125,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.ep_manager._delete_vrf_file = mock.Mock()
         agent.ep_manager.snat_iptables = mock.Mock()
         agent.ep_manager.snat_iptables.setup_snat_for_es = mock.Mock(
-            return_value = tuple([None, None]))
+            return_value=tuple([None, None]))
         agent.ep_manager._release_int_fip = mock.Mock()
 
         agent.opflex_networks = ['phys_net']
@@ -483,11 +483,11 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 self.assertEqual(vlan_info['endpoint_group_name'],
                     epargs[0][0][1].get('endpoint_group_name'))
             else:
-                self.assertEqual(None, epargs[0][0][1].get('svi'))
+                self.assertIsNone(epargs[0][0][1].get('svi'))
                 self.assertEqual(mapping['endpoint_group_name'],
                     epargs[0][0][1].get('endpoint_group_name'))
         else:
-            self.assertEqual(None, epargs[0][0][1].get('svi'))
+            self.assertIsNone(epargs[0][0][1].get('svi'))
             self.assertEqual(mapping['endpoint_group_name'],
                 epargs[0][0][1].get('endpoint_group_name'))
             self.assertEqual('', epargs[0][0][0].segmentation_id)

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -121,7 +121,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.ep_manager.snat_iptables.check_if_exists = mock.Mock(
             return_value=False)
         agent.ep_manager.snat_iptables.setup_snat_for_es = mock.Mock(
-            return_value = tuple([None, None]))
+            return_value=tuple([None, None]))
         agent.ep_manager._release_int_fip = mock.Mock()
 
         agent.opflex_networks = ['phys_net']
@@ -308,7 +308,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             agent = self._initialize_agent()
             self._mock_agent(agent)
             agent.bridge_manager.get_vif_port_set = mock.Mock(
-                return_value = {'uuid1': 'someint'})
+                return_value={'uuid1': 'someint'})
             agent._main_loop(set(), True, 1, port_stats, mock.Mock(), True)
             agent.ep_manager.undeclare_endpoint.assert_called_once_with(
                 'uuid2')

--- a/opflexagent/test/test_ovs_manager.py
+++ b/opflexagent/test/test_ovs_manager.py
@@ -89,7 +89,7 @@ class TestOVSManager(base.BaseTestCase):
         # Ports added
         new_curr = curr | set(['5', '6'])
         self.manager.int_br.get_vif_port_set = mock.Mock(
-            return_value= new_curr)
+            return_value=new_curr)
         res = self.manager.scan_ports(curr)
         self.assertEqual({'current': new_curr, 'added': set(['5', '6']),
                           'removed': set()}, res)

--- a/opflexagent/utils/bridge_managers/bridge_manager_base.py
+++ b/opflexagent/utils/bridge_managers/bridge_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -81,7 +81,7 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         self.int_br.set_secure_mode()
         self.int_br.set_db_attribute('Bridge', self.int_br.br_name,
                                      'protocols', '[]', check_error=True)
-        #self.int_br.reset_ofversion()
+        # self.int_br.reset_ofversion()
 
         self.fabric_br.create()
         self.fabric_br.set_secure_mode()

--- a/opflexagent/utils/bridge_managers/trunk_skeleton.py
+++ b/opflexagent/utils/bridge_managers/trunk_skeleton.py
@@ -44,7 +44,8 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
 
     def handle_subports(self, context, resource_type, subports, event_type,
                         trunk_id=None):
-        LOG.info("Handling subports %s event %s" % (subports, event_type))
+        LOG.info("Handling subports %(subports)s event %(event)s",
+                 {'subports': subports, 'event': event_type})
         if subports:
             trunk_id = trunk_id or subports[0].trunk_id
             if trunk_id in self.managed_trunks:
@@ -87,7 +88,7 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
                         self.context, trunk_id, constants.DEGRADED_STATUS)
 
     def manage_trunk(self, port):
-        LOG.debug("Managing trunk for port: %s" % port)
+        LOG.debug("Managing trunk for port: %s", port)
         if getattr(port, 'trunk_details', None):
             trunk_id = port.trunk_details['trunk_id']
             master_id = port.trunk_details['master_port_id']

--- a/opflexagent/utils/bridge_managers/vpp_manager.py
+++ b/opflexagent/utils/bridge_managers/vpp_manager.py
@@ -10,16 +10,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
+
 from neutron.agent.linux import ip_lib
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib import constants as lib_constants
+from oslo_log import log as logging
+
 from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import trunk_skeleton
 from opflexagent.vpplib.VPPApi import VPPApi
-import os
-from oslo_log import log as logging
-
 
 LOG = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
         agent_state['agent_type'] = ofcst.AGENT_TYPE_OPFLEX_VPP
         if 'configurations' not in agent_state:
             agent_state['configurations'] = {}
-        #only supported datapath type with VPP is netdev
+        # only supported datapath type with VPP is netdev
         agent_state['configurations']['datapath_type'] = 'netdev'
         agent_state['configurations']['vhostuser_socket_dir'] = (
             vpp_config.vhostuser_socket_dir)
@@ -162,9 +163,9 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
         dst_shell("vppctl create host-interface name %s" % port)
         dst_shell("vppctl set interface state %s up" % port)
 
-    #The following methods are called with host-interfaces for SNAT
-    #This feature is currently not implemented by VPP
-    #Hence stubbing it out
+    # The following methods are called with host-interfaces for SNAT
+    # This feature is currently not implemented by VPP
+    # Hence stubbing it out
     def delete_port(self, port):
         pass
 

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -12,9 +12,9 @@
 
 import copy
 import json
-import netaddr
 import os
 
+import netaddr
 from neutron_lib import constants as n_constants
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
@@ -110,7 +110,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
     def declare_endpoint(self, port, mapping):
         LOG.info("Endpoint declaration requested for port %s",
                  port.vif_id)
-        LOG.debug("Mapping file for port %(port)s, %(mapping)s" %
+        LOG.debug("Mapping file for port %(port)s, %(mapping)s",
                   {'port': port.vif_id, 'mapping': mapping})
 
         if not mapping:
@@ -372,8 +372,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         else:
             if (mapping.get('enable_dhcp_optimization', False) and
                'subnets' in mapping):
-                    self._map_dhcp_info(fixed_ips, mapping,
-                                        mapping_dict)
+                self._map_dhcp_info(fixed_ips, mapping, mapping_dict)
         ips_aap = []
 
         def filter_cidr_aaps(aaps):
@@ -487,7 +486,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             nested_domain_dict["interface-name"] = mapping_dict[
                     "interface-name"]
             nested_domain_dict["uuid"] = uuidutils.generate_uuid()
-            LOG.debug("lbiface file for port %(port)s: \n %(mapping)s" %
+            LOG.debug("lbiface file for port %(port)s: \n %(mapping)s",
                       {'port': port.vif_id, 'mapping': nested_domain_dict})
             lbiface_file_name = port.vif_id + '_' + mac
             self._write_lbiface_file(lbiface_file_name, nested_domain_dict)
@@ -503,7 +502,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 nested_domain_dict = nested_domain_dict.copy()
                 nested_domain_dict["interface-name"] = self.uplink_intf_name
                 nested_domain_dict["uuid"] = uuidutils.generate_uuid()
-                LOG.debug("Uplink lbiface file for %(intf)s: \n %(mapping)s" %
+                LOG.debug("Uplink lbiface file for %(intf)s: \n %(mapping)s",
                           {'intf': self.uplink_intf_name,
                            'mapping': nested_domain_dict})
                 self._write_lbiface_file(
@@ -515,7 +514,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 mapping_dict.pop('security-group', None)
 
         # Create one file per MAC address.
-        LOG.debug("Final endpoint file for port %(port)s: \n %(mapping)s" %
+        LOG.debug("Final endpoint file for port %(port)s: \n %(mapping)s",
                   {'port': port.vif_id, 'mapping': mapping_dict})
         file_name = port.vif_id + '_' + mac
         if master_port_id:
@@ -658,7 +657,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 elif key == 'ip6_gateway':
                     nh.ip6_gateway = parse_gateway(value)
             self.ext_seg_next_hop[es_name] = nh
-            LOG.debug("Found external segment: %s" % nh)
+            LOG.debug("Found external segment: %s", nh)
 
     def _fill_ip_mapping_info(self, port_id, port_mac, gbp_details, ips,
                               mapping):

--- a/opflexagent/utils/ep_managers/endpoint_manager_base.py
+++ b/opflexagent/utils/ep_managers/endpoint_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -80,9 +80,11 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
         return self
 
     def apply_config(self):
-        LOG.debug("Apply config, pending requests: %s. current responses: "
-                  "%s" % (self.pending_requests._pending_requests_by_device_id,
-                          self.response_by_device_id))
+        LOG.debug("Apply config, pending requests: %(reqs)s. current "
+                  "responses: %(resps)s",
+                  {'reqs':
+                   self.pending_requests._pending_requests_by_device_id,
+                   'resps': self.response_by_device_id})
         skipped = []
         response_by_device_id_copy = self.response_by_device_id
         self.response_by_device_id = {}
@@ -169,7 +171,7 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
                 self.response_by_device_id[detail['device']] = detail
             else:
                 LOG.warn("Endpoint update for port %s is malformed "
-                         "(request_id missing)" % detail.get('device'))
+                         "(request_id missing)", detail.get('device'))
             LOG.debug("Got response for port %(port_id)s in "
                       "%(secs)s seconds",
                       {'port_id': detail.get('device'),

--- a/opflexagent/utils/port_managers/port_manager_base.py
+++ b/opflexagent/utils/port_managers/port_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -10,11 +10,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from contextlib2 import ExitStack, contextmanager
+from contextlib2 import contextmanager
+from contextlib2 import ExitStack
 from neutron_lib.utils import runtime
+from oslo_log import log as logging
+
 from opflexagent.utils.bridge_managers import (
     bridge_manager_base as bridge_manager)
-from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 

--- a/opflexagent/vif_plug_vpp/vpp.py
+++ b/opflexagent/vif_plug_vpp/vpp.py
@@ -54,14 +54,14 @@ class VppPlugin(plugin.PluginBase):
 
     def describe(self):
         pp_ovs = objects.host_info.HostPortProfileInfo(
-            profile_object_name=
-            objects.vif.VIFPortProfileOpenVSwitch.__name__,
+            profile_object_name=(
+                objects.vif.VIFPortProfileOpenVSwitch.__name__),
             min_version="1.0",
             max_version="1.0",
         )
         pp_ovs_representor = objects.host_info.HostPortProfileInfo(
-            profile_object_name=
-            objects.vif.VIFPortProfileOVSRepresentor.__name__,
+            profile_object_name=(
+                objects.vif.VIFPortProfileOVSRepresentor.__name__),
             min_version="1.0",
             max_version="1.0",
         )

--- a/opflexagent/vpp_plug_firewall.py
+++ b/opflexagent/vpp_plug_firewall.py
@@ -11,11 +11,11 @@
 #    under the License.
 
 import functools
-from os_vif import objects
-from oslo_log import log as logging
 
 from nova.network import model
 import nova.network.os_vif_util as os_vif_util
+from os_vif import objects
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 

--- a/opflexagent/vpplib/VPPApi.py
+++ b/opflexagent/vpplib/VPPApi.py
@@ -315,8 +315,8 @@ class VPPApi(object):
 
         # Check for a socket error
         if 'sock_errno' in vint[0]:
-                if vint[0]['sock_errno'] != 0:
-                    return 2, ''
+            if vint[0]['sock_errno'] != 0:
+                return 2, ''
         else:
             return 3, ''
 

--- a/opflexagent/vpplib/hook.py
+++ b/opflexagent/vpplib/hook.py
@@ -11,8 +11,9 @@
 #    under the License.
 import os
 import signal
-import six
 import traceback
+
+import six
 
 # import logging
 # from log import RED, single_line_delim, double_line_delim
@@ -47,7 +48,8 @@ class Hook(object):
         @param api_name: name of the API
         @param api_args: tuple containing the API arguments
         """
-        self.LOG.debug("API: %s (%s)" % (api_name, api_args))
+        self.LOG.debug("API: %(name)s (%(args)s)",
+                       {'name': api_name, 'args': api_args})
 
     # noinspection PyTypeChecker
     def after_api(self, api_name, api_args):
@@ -58,7 +60,8 @@ class Hook(object):
         @param api_args: tuple containing the API arguments
         """
 
-        self.LOG.debug("API: %s (%s)" % (api_name, api_args))
+        self.LOG.debug("API: %(name)s (%(args)s)",
+                       {'name': api_name, 'args': api_args})
 
     def before_cli(self, cli):
         """
@@ -67,7 +70,7 @@ class Hook(object):
 
         @param cli: CLI string
         """
-        self.LOG.debug("CLI: %s" % cli)
+        self.LOG.debug("CLI: %s", cli)
 
     def after_cli(self, cli):
         """

--- a/opflexagent/vpplib/vpp_papi_provider.py
+++ b/opflexagent/vpplib/vpp_papi_provider.py
@@ -9,12 +9,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 from collections import deque
 import fnmatch
-from hook import Hook
 import logging
 import os
 import time
+
+from hook import Hook
 
 # Parse the VPP api json files once and store the object globally
 vpp_jsonfiles = []
@@ -134,7 +136,8 @@ class VppPapiProvider(object):
                     raise Exception(
                         "Unexpected event received: %s, expected: %s" %
                         (type(e).__name__, name))
-                self.LOG.debug("Returning event %s:%s" % (name, e))
+                self.LOG.debug("Returning event %(name)s:%(event)s",
+                               {'name': name, 'event': e})
                 return e
             time.sleep(0)  # yield
         raise Exception("Event did not occur within timeout")
@@ -143,7 +146,8 @@ class VppPapiProvider(object):
         """ Enqueue event in the internal event queue. """
         # FIXME use the name instead of relying on type(e).__name__ ?
         # FIXME #2 if this throws, it is eaten silently, Ole?
-        self.LOG.debug("New event: %s: %s" % (name, event))
+        self.LOG.debug("New event: %(name)s: %(event)s",
+                       {'name': name, 'event': event})
         self._events.append(event)
 
     def connect(self):
@@ -523,7 +527,8 @@ class VppPapiProvider(object):
                          'enable': enable})
 
     def bridge_flags(self, bd_id, is_set, feature_bitmap):
-        """Enable/disable required feature of the bridge domain with defined ID.
+        """
+        Enable/disable required feature of the bridge domain with defined ID.
 
         :param int bd_id: Bridge domain ID.
         :param int is_set: Set to 1 to enable, set to 0 to disable the feature.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,12 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
+hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
 
 -e git+https://opendev.org/openstack/neutron.git@stable/queens#egg=neutron
-hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+
 coverage!=4.4,>=4.0 # Apache-2.0
+flake8-import-order==0.12 # LGPLv3
 testtools>=2.2.0 # MIT
 testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,7 @@
 [tox]
 envlist = py27,py35,pep8
-minversion = 3.4.0
+minversion = 2.3.2
 skipsdist = True
-
-# REVISIT: Requiring the tox-venv tox plugin seems to avoid
-# installation of the latest setuptools version, which is incompatible
-# the 1.0 version of MarkupSafe pinned by
-# https://releases.openstack.org/constraints/upper/queens. This should
-# be removed for rocky and newer, which use newer MarkupSafe versions
-# that have resolved the setuptools incompatibility.
-requires = tox-venv
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -20,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
 passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 usedevelop = True
 install_command =
-  pip install {opts} {packages}
+  pip install -U {opts} {packages}
 deps =
   -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
   -r{toxinidir}/requirements.txt
@@ -47,26 +39,22 @@ commands =
 commands = {posargs}
 
 [flake8]
-# E125 continuation line does not distinguish itself from next logical line
 # E126 continuation line over-indented for hanging indent
 # E128 continuation line under-indented for visual indent
-# E129 visually indented line with same indent as next logical line
-# E251 unexpected spaces around keyword / parameter equals
-# E265 block comment should start with ‘# ‘
-# E713 test for membership should be ‘not in’
-# F402 import module shadowed by loop variable
-# F811 redefinition of unused variable
-# F812 list comprehension redefines name from line
-# H104 file contains nothing but comments
-# H237 module is removed in Python 3
-# H305 imports not grouped correctly
-# H307 like imports should be grouped together
-# H401 docstring should not start with a space
-# H402 one line docstring needs punctuation
+# E129 visually indented line with same indent as next logical line - REVISIT
+# E741 ambiguous variable name - REVISIT
+# H404 multi line docstring should start with a summary - REVISIT
 # H405 multi line docstring summary not separated with an empty line
-# H904 Wrap long lines in parentheses instead of a backslash
-# TODO(marun) H404 multi line docstring should start with a summary
-ignore = H202,H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
+# W504 line break after binary operator - REVISIT
+# W605 invalid escape sequence - REVISIT
+ignore = E126,E128,E129,E741,H401,H404,H405,W504,W605
+# H106: Don’t put vim configuration in source files
+# H203: Use assertIs(Not)None to check for None
+# H204: Use assert(Not)Equal to check for equality
+# H205: Use assert(Greater|Less)(Equal) for comparison
+# H904: Delay string interpolations at logging calls
+enable-extensions = H106,H203,H204,H205,H904
 show-source = true
 builtins = _
 exclude = .venv,.git,.tox,dist,doc,*openstack/common*,*neutron/common*,*lib/python*,*egg,build,tools,.ropeproject,rally-scenarios
+import-order-style = pep8


### PR DESCRIPTION
Improve the build/test process. Highlights include:

* Remove the workaround for the MarkupSafe compatability issue with
  stable/queenss that required a newer version of tox.

* Fix pep8 issues that result in failures with the versions of hacking
  and flake8 used by Neutron's stable/rocky through stable/train
  branches. These changes are not necessary with the hacking and
  flake8 versions used in stable/queens, but we want to minimize code
  differences across our currently supported stable branches.

* Enable flake8-import-order and fix all the pep8 issues that it
  uncovered, particularly with order and grouping of import
  statements.

* Update pep8 configuration in tox.ini to more closely match upstream
  Neutron, and fix resulting issues. Remaining ignored checks that
  should be fixed but haven't been are marked with REVISIT in tox.ini.