### PR TITLE
Cleanup Queens

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${OS_TEST_PATH:-./opflexagent/test}
+top_dir=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 
-
 matrix:
   include:
     - python: 2.7
@@ -9,15 +8,12 @@ matrix:
     - python: 2.7
       env:
         - TOX_ENV=pep8
-    - python: 3.6
+    - python: 3.5
       env:
-        - TOX_ENV=py36
-    - python: 3.6
-      env:
-        - TOX_ENV=pep8
+        - TOX_ENV=py35
+
 install:
   - pip install tox
-
 
 script:
   - tox -e $TOX_ENV

--- a/opflexagent/_i18n.py
+++ b/opflexagent/_i18n.py
@@ -1,0 +1,20 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import oslo_i18n
+
+_translators = oslo_i18n.TranslatorFactory(domain='python_opflex_agent')
+
+# The translation function using the well-known name "_"
+_ = _translators.primary

--- a/opflexagent/apic_topology.py
+++ b/opflexagent/apic_topology.py
@@ -17,8 +17,8 @@ import re
 import sys
 
 import eventlet
+eventlet.monkey_patch()  # noqa
 
-eventlet.monkey_patch()
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_service import periodic_task
@@ -32,6 +32,7 @@ from neutron import manager
 from neutron import service
 from neutron_lib.utils import net as net_utils
 
+from opflexagent._i18n import _
 from opflexagent import constants
 from opflexagent import host_agent_rpc as arpc
 

--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -13,29 +13,30 @@
 import functools
 import hashlib
 import multiprocessing
-import netaddr
 import os
 import os.path
-import pyinotify
 import signal
-from six.moves import queue as Queue
 import subprocess
 import sys
 import time
 import uuid
+
+import netaddr
+import pyinotify
+from six.moves import queue as Queue
 
 from neutron.common import config as common_config
 from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
-from opflexagent._i18n import _
-from opflexagent.utils import utils as opflexagent_utils
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 
+from opflexagent._i18n import _
 from opflexagent import config as oscfg  # noqa
+from opflexagent.utils import utils as opflexagent_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ def read_jsonfile(name):
         with open(name, "r") as f:
             retval = jsonutils.load(f)
     except Exception as e:
-        LOG.warn("Exception in reading file: %s" % str(e))
+        LOG.warn("Exception in reading file: %s", str(e))
     return retval
 
 
@@ -99,7 +100,7 @@ def write_jsonfile(name, data):
         with open(name, "w") as f:
             jsonutils.dump(data, f)
     except Exception as e:
-        LOG.warn("Exception in writing file: %s" % str(e))
+        LOG.warn("Exception in writing file: %s", str(e))
 
 
 class AddressPool(object):
@@ -128,13 +129,13 @@ class FileProcessor(object):
         self.processfn = processfn
 
     def scanfiles(self, files):
-        LOG.debug("FileProcessor: processing files: %s" % files)
+        LOG.debug("FileProcessor: processing files: %s", files)
         relevant_files = []
         for (action, filename) in files:
             if all(not filename.endswith(ext) for ext in self.extensions):
                 continue
             relevant_files.append((action, filename))
-        LOG.debug("FileProcessor: relevant files %s" % relevant_files)
+        LOG.debug("FileProcessor: relevant files %s", relevant_files)
         return self.processfn(relevant_files)
 
     def scan(self):
@@ -154,7 +155,7 @@ class FileProcessor(object):
                 event = self.eventq.get()
                 while event is not None:
                     # drain all events in queue and batch them
-                    LOG.debug("FileProcessor: event: %s" % event)
+                    LOG.debug("FileProcessor: event: %s", event)
                     if event == EOQ:
                         connected = False
                         event = None
@@ -176,7 +177,7 @@ class FileProcessor(object):
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            LOG.warn("FileProcessor: Exception: %s" % str(e))
+            LOG.warn("FileProcessor: Exception: %s", str(e))
         return
 
 
@@ -215,18 +216,19 @@ class FileWatcher(object):
             functools.partial(self.process))
         fprun = functools.partial(fp.run)
         self.processor = multiprocessing.Process(target=fprun)
-        LOG.debug("FileWatcher: %s: starting" % self.name)
+        LOG.debug("FileWatcher: %s: starting", self.name)
         self.processor.start()
 
     def action(self, event):
         # event.maskname, event.filename
-        LOG.debug("FileWatcher: %s: event: %s" % (self.name, event))
+        LOG.debug("FileWatcher: %(name)s: event: %(event)s",
+                  {'name': self.name, 'event': event})
         self.eventq.put(event)
 
     def process(self, files):
         # Override in child class
-        LOG.debug("FileWatcher: %s: process: %s" % (
-            self.name, files))
+        LOG.debug("FileWatcher: %(name)s: process: %(files)s",
+                  {'name': self.name, 'files': files})
 
     def terminate(self, signum, frame):
         self.eventq.put(EOQ)
@@ -242,13 +244,13 @@ class FileWatcher(object):
         notifier = pyinotify.Notifier(wm, handler)
         wm.add_watch(self.watchdir, handler.events, rec=False)
         try:
-            LOG.debug("FileWatcher: %s: notifier waiting ..." % self.name)
+            LOG.debug("FileWatcher: %s: notifier waiting ...", self.name)
             notifier.loop()
         finally:
-            LOG.debug("FileWatcher: %s: notifier returned" % self.name)
+            LOG.debug("FileWatcher: %s: notifier returned", self.name)
             self.terminate(None, None)
 
-        LOG.debug("FileWatcher: %s: processor returned" % self.name)
+        LOG.debug("FileWatcher: %s: processor returned", self.name)
         self.processor.join()
         return True
 
@@ -262,7 +264,7 @@ class TmpWatcher(FileWatcher):
             filedir, extensions, name="ep-watcher")
 
     def process(self, files):
-        LOG.debug("TmpWatcher files: %s" % files)
+        LOG.debug("TmpWatcher files: %s", files)
 
 
 class EpWatcher(FileWatcher):
@@ -315,7 +317,7 @@ class EpWatcher(FileWatcher):
         return fquuid
 
     def process(self, files):
-        LOG.debug("EP files: %s" % files)
+        LOG.debug("EP files: %s", files)
 
         curr_svc = read_jsonfile(self.svcfile)
         ip_pool = AddressPool(SVC_IP_BASE, SVC_IP_SIZE)
@@ -406,7 +408,7 @@ class StateWatcher(FileWatcher):
         super(StateWatcher, self).terminate(signum, frame)
 
     def process(self, files):
-        LOG.debug("State Event: %s" % files)
+        LOG.debug("State Event: %s", files)
 
         curr_alloc = read_jsonfile(self.svcfile)
 
@@ -440,16 +442,15 @@ class StateWatcher(FileWatcher):
         for idx in ["uuid", "domain-name", "domain-policy-space"]:
             if asvc[idx] != alloc[idx]:
                 return False
-        if asvc["service-mapping"][0]["next-hop-ip"] != \
-           alloc["next-hop-ip"]:
-                return False
+        if asvc["service-mapping"][0]["next-hop-ip"] != alloc["next-hop-ip"]:
+            return False
         return True
 
     def as_del(self, filename, asvc):
         try:
             self.mgr.del_ip(asvc["service-mapping"]["next-hop-ip"])
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in deleting IP: %s" %
+            LOG.warn("EPwatcher: Exception in deleting IP: %s",
                      str(e))
 
         proxyfilename = PROXY_FILE_NAME_FORMAT % asvc["uuid"]
@@ -458,7 +459,7 @@ class StateWatcher(FileWatcher):
             os.remove(filename)
             os.remove(proxyfilename)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in deleting file: %s" % str(e))
+            LOG.warn("EPwatcher: Exception in deleting file: %s", str(e))
 
     def as_create(self, alloc):
         asvc = {
@@ -479,7 +480,7 @@ class StateWatcher(FileWatcher):
         try:
             self.mgr.add_ip(alloc["next-hop-ip"])
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in adding IP: %s" %
+            LOG.warn("EPwatcher: Exception in adding IP: %s",
                      str(e))
 
         asfilename = AS_FILE_NAME_FORMAT % asvc["uuid"]
@@ -488,7 +489,7 @@ class StateWatcher(FileWatcher):
             with open(asfilename, "w") as f:
                 jsonutils.dump(asvc, f)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in writing services file: %s" %
+            LOG.warn("EPwatcher: Exception in writing services file: %s",
                      str(e))
 
         proxyfilename = PROXY_FILE_NAME_FORMAT % asvc["uuid"]
@@ -500,7 +501,7 @@ class StateWatcher(FileWatcher):
             pidfile = PID_FILE_NAME_FORMAT % asvc["uuid"]
             self.mgr.sh("rm -f %s" % pidfile)
         except Exception as e:
-            LOG.warn("EPwatcher: Exception in writing proxy file: %s" %
+            LOG.warn("EPwatcher: Exception in writing proxy file: %s",
                      str(e))
 
     def proxyconfig(self, alloc):
@@ -545,7 +546,7 @@ class SnatConnTrackHandler(object):
             self.mgr.sh("rm -f %s" % pidfile)
             self.mgr.update_supervisor()
         except Exception as e:
-            LOG.warn("ConnTrack: Exception in writing snat file: %s" %
+            LOG.warn("ConnTrack: Exception in writing snat file: %s",
                      str(e))
 
     def conn_track_del(self, netns):
@@ -555,7 +556,7 @@ class SnatConnTrackHandler(object):
             os.remove(snatfilename)
             self.mgr.update_supervisor()
         except Exception as e:
-            LOG.warn("ConnTrack: Exception in deleting file: %s" % str(e))
+            LOG.warn("ConnTrack: Exception in deleting file: %s", str(e))
 
     def conn_track_config(self, netns):
         snatstr = "\n".join([
@@ -597,8 +598,9 @@ class AsMetadataManager(object):
                 self.init_all()
                 self.initialized = True
             except Exception as e:
-                LOG.error("%s: in initializing anycast metadata service: %s" %
-                          (self.name, str(e)))
+                LOG.error("%(name)s: in initializing anycast metadata "
+                          "service: %(exc)s",
+                          {'name': self.name, 'exc': str(e)})
 
     def ensure_terminated(self):
         if self.initialized:
@@ -607,27 +609,29 @@ class AsMetadataManager(object):
                 self.clean_files()
                 self.stop_supervisor()
             except Exception as e:
-                LOG.error("%s: in shuttingdown anycast metadata service: %s" %
-                          (self.name, str(e)))
+                LOG.error("%(name)s: in shuttingdown anycast metadata "
+                          "service: %(exc)s",
+                          {'name': self.name, 'exc': str(e)})
 
     def sh(self, cmd, as_root=True):
         if as_root and self.root_helper:
             cmd = "%s %s" % (self.root_helper, cmd)
-        LOG.debug("%s: Running command: %s" % (
-            self.name, cmd))
+        LOG.debug("%(name)s: Running command: %(cmd)s",
+                  {'name': self.name, 'cmd': cmd})
         ret = ''
         try:
             ret = subprocess.check_output(
                 cmd, stderr=subprocess.STDOUT, shell=True)
         except Exception as e:
-            LOG.error("In running command: %s: %s" % (cmd, str(e)))
-        LOG.debug("%s: Command output: %s" % (
-            self.name, ret))
+            LOG.error("In running command: %(cmd)s: %(exc)s",
+                      {'cmd': cmd, 'exc': str(e)})
+        LOG.debug("%(name)s: Command output: %(ret)s",
+                  {'name': self.name, 'ret': ret})
         return ret
 
     def write_file(self, name, data):
-        LOG.debug("%s: Writing file: name=%s, data=%s" % (
-            self.name, name, data))
+        LOG.debug("%(name)s: Writing file: name=%(file)s, data=%(data)s",
+                  {'name': self.name, 'file': name, 'data': data})
         with open(name, "w") as f:
             f.write(data)
 

--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -29,6 +29,7 @@ from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
+from opflexagent._i18n import _
 from opflexagent.utils import utils as opflexagent_utils
 from oslo_config import cfg
 from oslo_log import log as logging

--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -12,6 +12,8 @@
 
 from oslo_config import cfg
 
+from opflexagent._i18n import _
+
 
 gbp_opts = [
     cfg.StrOpt('epg_mapping_dir',

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -209,9 +209,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     (physical_network in self.opflex_networks)):
                 # Endpoint Manager to process the EP info
                 LOG.debug("Processing the endpoint mapping "
-                          "for port %(port)s: \n mapping: %(mapping)s" % {
-                              'port': port.vif_id,
-                              'mapping': port.gbp_details})
+                          "for port %(port)s: \n mapping: %(mapping)s",
+                          {'port': port.vif_id,
+                           'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
                 LOG.error("Cannot provision OPFLEX network for "
@@ -224,9 +224,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     (physical_network in self.vlan_networks)):
                 # Endpoint Manager to process the EP info
                 LOG.debug("Processing the endpoint mapping "
-                          "for port %(port)s: \n mapping: %(mapping)s" % {
-                              'port': port.vif_id,
-                              'mapping': port.gbp_details})
+                          "for port %(port)s: \n mapping: %(mapping)s",
+                          {'port': port.vif_id,
+                           'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
                 LOG.error("Cannot provision VLAN network for "
@@ -355,7 +355,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                         # No need to rerise, port could be bound somehow else
                         ctx.reraise = False
                         LOG.warn("Device %s not found while disabling mac "
-                                 "learning" % br_name)
+                                 "learning", br_name)
 
     def treat_devices_added_or_updated(self, details):
         """Process added or updated devices
@@ -380,8 +380,8 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 details.pop('port_id', None)
             if (gbp_details and gbp_details.get('host') and
                 gbp_details['host'] != self.host):
-                    self.port_unbound(device)
-                    return False
+                self.port_unbound(device)
+                return False
             elif neutron_details and 'port_id' in neutron_details:
                 LOG.info("Port %(device)s updated. Details: %(details)s",
                          {'device': device, 'details': details})

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -18,24 +18,26 @@ import time
 # We need to ensure that the monkey-patch gets applied
 # before other packages that use eventlet get imported
 from neutron.common import eventlet_utils  # noqa
-eventlet_utils.monkey_patch()
+eventlet_utils.monkey_patch()  # noqa
 
 from neutron.agent.common import ip_lib
 from neutron.agent.common import polling
 from neutron.agent.linux import iptables_firewall
 from neutron.agent import rpc as agent_rpc
-from neutron.agent import securitygroups_rpc as sg_rpc
+from neutron.agent import securitygroups_rpc as agent_sg_rpc
+from neutron.api.rpc.handlers import securitygroups_rpc as sg_rpc
 from neutron.common import config as common_config
-from neutron.common import topics
 from neutron.common import utils as q_utils
 from neutron.conf.agent import common as config
 from neutron.conf.agent import dhcp as dhcp_config
 from neutron.plugins.ml2.drivers.openvswitch.agent import (
     ovs_neutron_agent as ovs)
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
+from neutron_lib.agent import topics
 from neutron_lib import constants as n_constants
 from neutron_lib import context
 from neutron_lib import exceptions
+from opflexagent._i18n import _
 from opflexagent import as_metadata_manager
 from opflexagent import constants as ofcst
 from opflexagent import opflex_notify
@@ -162,7 +164,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         self.of_rpc = rpc.GBPServerRpcApi(rpc.TOPIC_OPFLEX)
         self.plugin_rpc = ovs.OVSPluginApi(topics.PLUGIN)
         self.sg_plugin_rpc = sg_rpc.SecurityGroupServerRpcApi(topics.PLUGIN)
-        self.sg_agent = sg_rpc.SecurityGroupAgentRpc(
+        self.sg_agent = agent_sg_rpc.SecurityGroupAgentRpc(
             self.context, self.sg_plugin_rpc, defer_refresh_firewall=True)
 
         self.state_rpc = agent_rpc.PluginReportStateAPI(topics.PLUGIN)
@@ -212,9 +214,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                               'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
-                LOG.error(_("Cannot provision OPFLEX network for "
-                            "net-id=%(net_uuid)s - no bridge for "
-                            "physical_network %(physical_network)s"),
+                LOG.error("Cannot provision OPFLEX network for "
+                          "net-id=%(net_uuid)s - no bridge for "
+                          "physical_network %(physical_network)s",
                           {'net_uuid': net_uuid,
                            'physical_network': physical_network})
         elif network_type == n_constants.TYPE_VLAN:
@@ -227,15 +229,15 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                               'mapping': port.gbp_details})
                 self.port_bound(port)
             else:
-                LOG.error(_("Cannot provision VLAN network for "
-                            "net-id=%(net_uuid)s - no bridge for "
-                            "physical_network %(physical_network)s"),
+                LOG.error("Cannot provision VLAN network for "
+                          "net-id=%(net_uuid)s - no bridge for "
+                          "physical_network %(physical_network)s",
                           {'net_uuid': net_uuid,
                            'physical_network': physical_network})
         else:
-            LOG.error(_("Network type %(net_type)s not supported for "
-                        "Policy Target provisioning. Supported types: "
-                        "%(supported)s"),
+            LOG.error("Network type %(net_type)s not supported for "
+                      "Policy Target provisioning. Supported types: "
+                      "%(supported)s",
                       {'net_type': network_type,
                        'supported': self.supported_pt_network_types})
 
@@ -381,7 +383,7 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     self.port_unbound(device)
                     return False
             elif neutron_details and 'port_id' in neutron_details:
-                LOG.info(_("Port %(device)s updated. Details: %(details)s"),
+                LOG.info("Port %(device)s updated. Details: %(details)s",
                          {'device': device, 'details': details})
                 # Inject GBP/Trunk details
                 port.gbp_details = gbp_details
@@ -396,24 +398,24 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                                     neutron_details['segmentation_id'])
                 # update plugin about port status
                 if neutron_details.get('admin_state_up'):
-                    LOG.debug(_("Setting status for %s to UP"), device)
+                    LOG.debug("Setting status for %s to UP", device)
                     self.plugin_rpc.update_device_up(
                         self.context, device, self.agent_id, self.host)
                 else:
-                    LOG.debug(_("Setting status for %s to DOWN"), device)
+                    LOG.debug("Setting status for %s to DOWN", device)
                     self.plugin_rpc.update_device_down(
                         self.context, device, self.agent_id, self.host)
-                LOG.info(_("Configuration for device %s completed."),
+                LOG.info("Configuration for device %s completed.",
                          device)
             else:
-                LOG.warn(_("Device %s not defined on plugin"), device)
+                LOG.warn("Device %s not defined on plugin", device)
                 if port and port.ofport != -1:
                     self.port_unbound(port.vif_id)
                     return False
         else:
             # The port disappeared and cannot be processed
-            LOG.info(_("Port %s was not found on the integration bridge "
-                       "and will therefore not be processed"), device)
+            LOG.info("Port %s was not found on the integration bridge "
+                     "and will therefore not be processed", device)
             self.port_unbound(device)
             return False
         return True
@@ -589,26 +591,20 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
 
 def _parse_files(conf_files):
-    try:
-        multi_parser = cfg.MultiConfigParser()
-        multi_parser.read(conf_files)
-        return multi_parser.parsed
-    except AttributeError:
-        # Oslo 6.0.0+
-        sections = {}
-        for filename in conf_files:
-            parser = cfg.ConfigParser(filename, sections)
-            try:
-                parser.parse()
-            except IOError:
-                LOG.warning('IOError failure on %(file)s: %(exc)s',
-                            {'file': filename,
-                             'exc': '(file missing or permission issue?)'})
-                continue
-            except Exception as e:
-                LOG.warning('Failed to parse file %(file)s: %(exc)s',
-                            {'file': filename, 'exc': e})
-        return [sections]
+    sections = {}
+    for filename in conf_files:
+        parser = cfg.ConfigParser(filename, sections)
+        try:
+            parser.parse()
+        except IOError:
+            LOG.warning('IOError failure on %(file)s: %(exc)s',
+                        {'file': filename,
+                         'exc': '(file missing or permission issue?)'})
+            continue
+        except Exception as e:
+            LOG.warning('Failed to parse file %(file)s: %(exc)s',
+                        {'file': filename, 'exc': e})
+    return [sections]
 
 
 def create_agent_config_map(conf):
@@ -670,7 +666,7 @@ def main():
     if not agent:
         sys.exit(1)
 
-    LOG.info(_("Agent initialized successfully, now running... "))
+    LOG.info("Agent initialized successfully, now running... ")
     agent.daemon_loop()
 
 
@@ -678,7 +674,7 @@ def agent_startup_helper(create_config_map_fn, agent_class, root_helper=None):
     try:
         agent_config = create_config_map_fn(cfg.CONF)
     except ValueError as e:
-        LOG.error(_("Couldn't create config map (%s), Agent terminated!"), e)
+        LOG.error("Couldn't create config map (%s), Agent terminated!", e)
         return None
 
     try:
@@ -688,7 +684,7 @@ def agent_startup_helper(create_config_map_fn, agent_class, root_helper=None):
             agent = agent_class(**agent_config)
 
     except RuntimeError as e:
-        LOG.error(_("Couldn't create agent (%s), Agent terminated!"), e)
+        LOG.error("Couldn't create agent (%s), Agent terminated!", e)
         return None
     signal.signal(signal.SIGTERM, agent._handle_sigterm)
     return agent
@@ -753,7 +749,7 @@ def main_opflex():
                          root_helper=root_helper)
 
     # Start everything.
-    LOG.info(_("Initializing metadata service ... "))
+    LOG.info("Initializing metadata service ... ")
     helper = cfg.CONF.AGENT.root_helper
     metadata_mgr = as_metadata_manager.AsMetadataManager(LOG, helper)
     metadata_mgr.ensure_initialized()

--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -74,14 +74,14 @@ class NetworkMetadataProxyHandler(object):
             with open(fqfn, "r") as f:
                 nets = jsonutils.load(f)
         except Exception as e:
-            LOG.warning("Exception in reading file: %s" % str(e))
+            LOG.warning("Exception in reading file: %s", str(e))
 
         if nets:
             if domain_id in nets:
                 if remote_address in nets[domain_id]:
                     return nets[domain_id][remote_address]
-        LOG.warning("IP address not found: domain=%s, addr=%s" % (
-                    domain_id, remote_address))
+        LOG.warning("IP address not found: domain=%(domain)s, addr=%(addr)s",
+                    {'domain': domain_id, 'addr': remote_address})
         return None
 
     def _proxy_request(self, remote_address, method, path_info,

--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -26,6 +26,8 @@ from neutron.common import utils
 from neutron import wsgi
 from oslo_serialization import jsonutils
 
+from opflexagent._i18n import _
+
 LOG = logging.getLogger(__name__)
 
 

--- a/opflexagent/opflex_conn_track.py
+++ b/opflexagent/opflex_conn_track.py
@@ -60,12 +60,12 @@ class SnatConntrackLogger(object):
             self.p2 = subprocess.Popen(
                 logger_cmd, stdin=self.p1.stdout, close_fds=True, shell=True)
         except Exception as e:
-            LOG.error("In running commands: %s: %s" %
-                      (conntrack_cmd + logger_cmd, str(e)))
+            LOG.error("In running commands: %(cmds)s: %(exc)s",
+                      {'cmds': conntrack_cmd + logger_cmd, 'exc': str(e)})
 
     def _kill_child_procs(self):
         for proc in [self.p1, self.p2]:
-            LOG.debug("conn_track: proc: %s" % proc.returncode)
+            LOG.debug("conn_track: proc: %s", proc.returncode)
             try:
                 proc.terminate()
             except Exception:
@@ -73,7 +73,7 @@ class SnatConntrackLogger(object):
 
     def terminate(self, signum, frame):
         self._kill_child_procs()
-        LOG.debug("conn_track: returning %s" % -signum)
+        LOG.debug("conn_track: returning %s", -signum)
         sys.exit(-signum)
 
     def wait(self):
@@ -107,13 +107,13 @@ def main():
     cmd1 = ("ip netns exec %s conntrack -E -o timestamp") % (sys.argv[1])
     cmd2 = ("logger -p %s.%s -t opflex-conn-track") % (sys.argv[2],
                                                        sys.argv[3])
-    LOG.debug("conn_track command: %s" % cmd1)
-    LOG.debug("logger command: %s" % cmd2)
+    LOG.debug("conn_track command: %s", cmd1)
+    LOG.debug("logger command: %s", cmd2)
     wrapper = SnatConntrackLogger(cmd1, cmd2)
     return wrapper.wait()
 
 
 if __name__ == "__main__":
     ret = main()
-    LOG.debug("conn_track: returning %s" % ret)
+    LOG.debug("conn_track: returning %s", ret)
     sys.exit(ret)

--- a/opflexagent/rpc.py
+++ b/opflexagent/rpc.py
@@ -11,7 +11,7 @@
 #    under the License.
 
 from neutron.common import rpc as n_rpc
-from neutron.common import topics
+from neutron_lib.agent import topics
 from oslo_log import helpers as log
 from oslo_log import log as logging
 import oslo_messaging

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -12,8 +12,8 @@
 
 
 import hashlib
-import netaddr
 
+import netaddr
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import iptables_manager
 from oslo_config import cfg

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -133,20 +133,20 @@ class SnatIptablesManager(object):
         if_dev = self._add_port_and_netns(next_hop_if, ns,
                                           if_mac=next_hop_mac, mtu=mtu)
         next_hop_mac = if_dev.link.address
-        LOG.debug(_("Created namespace %(ns)s, and added port %(pt)s to it"),
+        LOG.debug("Created namespace %(ns)s, and added port %(pt)s to it",
                   {'ns': ns, 'pt': next_hop_if})
 
         if use_v4:
             self._setup_routes(if_dev, 4, ip_start, ip_end, ip_gw)
-            LOG.debug(_("Set IPv4 address and routes"))
+            LOG.debug("Set IPv4 address and routes")
 
         if use_v6:
             self._setup_routes(if_dev, 6, ip6_start, ip6_end, ip6_gw)
-            LOG.debug(_("Set IPv6 address and routes"))
+            LOG.debug("Set IPv6 address and routes")
 
         self._setup_iptables(ns, next_hop_if, ip_start, ip_end,
                              ip6_start, ip6_end)
-        LOG.debug(_("Installed iptables rules"))
+        LOG.debug("Installed iptables rules")
         return (next_hop_if, next_hop_mac)
 
     def cleanup_snat_for_es(self, es_name, next_hop_if=None):

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -186,12 +186,12 @@ class TestAsyncPortManager(base.BaseTestCase):
 
     def test_apply_config_fails(self):
         self.agent.treat_devices_added_or_updated = mock.Mock(
-            side_effect=Exception)
+            side_effect=ValueError)
         to_schedule = set(['1', '2', '3', '4'])
         self.manager.schedule_update(to_schedule)
         update = self._get_device_requests(['1', '2', '4'])
         self.manager._opflex_endpoint_update(mock.Mock(), update)
-        self.assertRaises(Exception, self.manager.apply_config)
+        self.assertRaises(ValueError, self.manager.apply_config)
         # responses are restored after the exception
         self.assertEqual(3, len(self.manager.response_by_device_id))
 

--- a/opflexagent/test/test_async_port_manager.py
+++ b/opflexagent/test/test_async_port_manager.py
@@ -13,8 +13,8 @@
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent.utils.port_managers import async_port_manager

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -16,8 +16,8 @@ import sys
 
 import mock
 from mock import call
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1151,7 +1151,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
 
         self.assertEqual(False,
             epargs[1][0][1].get('neutron-metadata-optimization'))
-        self.assertEqual(None, epargs[1][0][1].get('dhcp4'))
+        self.assertIsNone(epargs[1][0][1].get('dhcp4'))
 
     def test_vlan_net_no_svi_port_bound(self):
         self._test_vlan_net_port_bound()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -125,7 +125,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.ep_manager._delete_vrf_file = mock.Mock()
         agent.ep_manager.snat_iptables = mock.Mock()
         agent.ep_manager.snat_iptables.setup_snat_for_es = mock.Mock(
-            return_value = tuple([None, None]))
+            return_value=tuple([None, None]))
         agent.ep_manager._release_int_fip = mock.Mock()
 
         agent.opflex_networks = ['phys_net']
@@ -483,11 +483,11 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 self.assertEqual(vlan_info['endpoint_group_name'],
                     epargs[0][0][1].get('endpoint_group_name'))
             else:
-                self.assertEqual(None, epargs[0][0][1].get('svi'))
+                self.assertIsNone(epargs[0][0][1].get('svi'))
                 self.assertEqual(mapping['endpoint_group_name'],
                     epargs[0][0][1].get('endpoint_group_name'))
         else:
-            self.assertEqual(None, epargs[0][0][1].get('svi'))
+            self.assertIsNone(epargs[0][0][1].get('svi'))
             self.assertEqual(mapping['endpoint_group_name'],
                 epargs[0][0][1].get('endpoint_group_name'))
             self.assertEqual('', epargs[0][0][0].segmentation_id)

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -14,8 +14,8 @@ import shutil
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager
@@ -412,8 +412,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         trunk_details['subports'] = subports
         port.trunk_details = trunk_details
 
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.assertFalse(self.agent.bridge_manager.add_patch_ports.called)
         self.assertFalse(self.agent.bridge_manager.delete_patch_ports.called)
 

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -121,7 +121,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         agent.ep_manager.snat_iptables.check_if_exists = mock.Mock(
             return_value=False)
         agent.ep_manager.snat_iptables.setup_snat_for_es = mock.Mock(
-            return_value = tuple([None, None]))
+            return_value=tuple([None, None]))
         agent.ep_manager._release_int_fip = mock.Mock()
 
         agent.opflex_networks = ['phys_net']
@@ -308,7 +308,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             agent = self._initialize_agent()
             self._mock_agent(agent)
             agent.bridge_manager.get_vif_port_set = mock.Mock(
-                return_value = {'uuid1': 'someint'})
+                return_value={'uuid1': 'someint'})
             agent._main_loop(set(), True, 1, port_stats, mock.Mock(), True)
             agent.ep_manager.undeclare_endpoint.assert_called_once_with(
                 'uuid2')

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -14,10 +14,10 @@ import shutil
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
-sys.modules['opflexagent.vpplib'] = mock.MagicMock()
-sys.modules['opflexagent.vpplib.VPPApi'] = mock.MagicMock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
+sys.modules['opflexagent.vpplib'] = mock.MagicMock()  # noqa
+sys.modules['opflexagent.vpplib.VPPApi'] = mock.MagicMock()  # noqa
 
 from neutron.api.rpc.callbacks import events
 from neutron.conf.agent import dhcp as dhcp_config
@@ -393,8 +393,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 port_id=uuidutils.generate_uuid(), trunk_id=trunk_id,
                 segmentation_type='foo', segmentation_id=i)
             for i in range(2)]
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.assertFalse(self.agent.bridge_manager.add_patch_ports.called)
         self.assertFalse(self.agent.bridge_manager.delete_patch_ports.called)
         self.agent.bridge_manager.managed_trunks[trunk_id] = 'master_port'
@@ -406,8 +408,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.agent.bridge_manager.trunk_rpc.update_subport_bindings = (
             binding_call)
 
-        self.agent.bridge_manager.handle_subports(subports, events.CREATED)
-        self.agent.bridge_manager.handle_subports(subports, events.DELETED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.CREATED)
+        self.agent.bridge_manager.handle_subports(
+            None, None, subports, events.DELETED)
         self.agent.bridge_manager.add_patch_ports.assert_called_with(
             [subports[0].port_id, subports[1].port_id],
             attached_macs={subports[0].port_id: '0', subports[1].port_id: '1'})

--- a/opflexagent/test/test_ovs_manager.py
+++ b/opflexagent/test/test_ovs_manager.py
@@ -14,8 +14,8 @@ import contextlib
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent.utils.bridge_managers import ovs_manager
 

--- a/opflexagent/test/test_ovs_manager.py
+++ b/opflexagent/test/test_ovs_manager.py
@@ -89,7 +89,7 @@ class TestOVSManager(base.BaseTestCase):
         # Ports added
         new_curr = curr | set(['5', '6'])
         self.manager.int_br.get_vif_port_set = mock.Mock(
-            return_value= new_curr)
+            return_value=new_curr)
         res = self.manager.scan_ports(curr)
         self.assertEqual({'current': new_curr, 'added': set(['5', '6']),
                           'removed': set()}, res)

--- a/opflexagent/test/test_rpc.py
+++ b/opflexagent/test/test_rpc.py
@@ -13,8 +13,8 @@
 import sys
 
 import mock
-sys.modules["apicapi"] = mock.Mock()
-sys.modules["pyinotify"] = mock.Mock()
+sys.modules["apicapi"] = mock.Mock()  # noqa
+sys.modules["pyinotify"] = mock.Mock()  # noqa
 
 from opflexagent import rpc
 from opflexagent.test import base

--- a/opflexagent/type_opflex.py
+++ b/opflexagent/type_opflex.py
@@ -16,6 +16,7 @@ from neutron_lib.plugins.ml2 import api
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from opflexagent._i18n import _
 from opflexagent import constants
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ cfg.CONF.register_opts(flat_opts, "ml2_type_opflex")
 class OpflexTypeDriver(helpers.BaseTypeDriver):
 
     def __init__(self):
-        LOG.info(_("ML2 OpflexTypeDriver initialization complete"))
+        LOG.info("ML2 OpflexTypeDriver initialization complete")
         self.default_opflex_network = (cfg.CONF.ml2_type_opflex.
                                        default_opflex_network)
         super(OpflexTypeDriver, self).__init__()

--- a/opflexagent/utils/bridge_managers/bridge_manager_base.py
+++ b/opflexagent/utils/bridge_managers/bridge_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -81,7 +81,7 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         self.int_br.set_secure_mode()
         self.int_br.set_db_attribute('Bridge', self.int_br.br_name,
                                      'protocols', '[]', check_error=True)
-        #self.int_br.reset_ofversion()
+        # self.int_br.reset_ofversion()
 
         self.fabric_br.create()
         self.fabric_br.set_secure_mode()

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -13,6 +13,7 @@
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib import constants as n_constants
 from neutron_lib.utils import helpers
+from opflexagent._i18n import _
 from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import ovs_lib

--- a/opflexagent/utils/bridge_managers/trunk_skeleton.py
+++ b/opflexagent/utils/bridge_managers/trunk_skeleton.py
@@ -44,7 +44,8 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
 
     def handle_subports(self, context, resource_type, subports, event_type,
                         trunk_id=None):
-        LOG.info("Handling subports %s event %s" % (subports, event_type))
+        LOG.info("Handling subports %(subports)s event %(event)s",
+                 {'subports': subports, 'event': event_type})
         if subports:
             trunk_id = trunk_id or subports[0].trunk_id
             if trunk_id in self.managed_trunks:
@@ -87,7 +88,7 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
                         self.context, trunk_id, constants.DEGRADED_STATUS)
 
     def manage_trunk(self, port):
-        LOG.debug("Managing trunk for port: %s" % port)
+        LOG.debug("Managing trunk for port: %s", port)
         if getattr(port, 'trunk_details', None):
             trunk_id = port.trunk_details['trunk_id']
             master_id = port.trunk_details['master_port_id']

--- a/opflexagent/utils/bridge_managers/trunk_skeleton.py
+++ b/opflexagent/utils/bridge_managers/trunk_skeleton.py
@@ -30,7 +30,7 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
         super(OpflexTrunkMixin, self).__init__()
         self.managed_trunks = {}
         registry.unsubscribe(self.handle_trunks, resources.TRUNK)
-        registry.subscribe(self.handle_subports, resources.SUBPORT)
+        registry.register(self.handle_subports, resources.SUBPORT)
         self._context = n_context.get_admin_context_without_session()
         self.trunk_rpc = agent.TrunkStub()
 
@@ -39,10 +39,11 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
         self._context.request_id = o_context.generate_request_id()
         return self._context
 
-    def handle_trunks(self, trunks, event_type):
+    def handle_trunks(self, context, resource_type, trunks, event_type):
         pass
 
-    def handle_subports(self, subports, event_type, trunk_id=None):
+    def handle_subports(self, context, resource_type, subports, event_type,
+                        trunk_id=None):
         LOG.info("Handling subports %s event %s" % (subports, event_type))
         if subports:
             trunk_id = trunk_id or subports[0].trunk_id
@@ -107,8 +108,9 @@ class OpflexTrunkMixin(agent.TrunkSkeleton):
                         segmentation_type=x['segmentation_type'],
                         segmentation_id=x['segmentation_id'])
                     for x in port.trunk_details['subports']]
-                self.handle_subports(subports, events.CREATED,
-                                     trunk_id=trunk_id)
+                self.handle_subports(
+                    self.context, None, subports, events.CREATED,
+                    trunk_id=trunk_id)
             self.trunk_rpc.update_trunk_status(self.context, trunk_id,
                                                constants.ACTIVE_STATUS)
 

--- a/opflexagent/utils/bridge_managers/vpp_manager.py
+++ b/opflexagent/utils/bridge_managers/vpp_manager.py
@@ -10,16 +10,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
+
 from neutron.agent.linux import ip_lib
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
 from neutron_lib import constants as lib_constants
+from oslo_log import log as logging
+
 from opflexagent import constants as ofcst
 from opflexagent.utils.bridge_managers import bridge_manager_base
 from opflexagent.utils.bridge_managers import trunk_skeleton
 from opflexagent.vpplib.VPPApi import VPPApi
-import os
-from oslo_log import log as logging
-
 
 LOG = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
         agent_state['agent_type'] = ofcst.AGENT_TYPE_OPFLEX_VPP
         if 'configurations' not in agent_state:
             agent_state['configurations'] = {}
-        #only supported datapath type with VPP is netdev
+        # only supported datapath type with VPP is netdev
         agent_state['configurations']['datapath_type'] = 'netdev'
         agent_state['configurations']['vhostuser_socket_dir'] = (
             vpp_config.vhostuser_socket_dir)
@@ -162,9 +163,9 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
         dst_shell("vppctl create host-interface name %s" % port)
         dst_shell("vppctl set interface state %s up" % port)
 
-    #The following methods are called with host-interfaces for SNAT
-    #This feature is currently not implemented by VPP
-    #Hence stubbing it out
+    # The following methods are called with host-interfaces for SNAT
+    # This feature is currently not implemented by VPP
+    # Hence stubbing it out
     def delete_port(self, port):
         pass
 

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -12,9 +12,9 @@
 
 import copy
 import json
-import netaddr
 import os
 
+import netaddr
 from neutron_lib import constants as n_constants
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
@@ -110,7 +110,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
     def declare_endpoint(self, port, mapping):
         LOG.info("Endpoint declaration requested for port %s",
                  port.vif_id)
-        LOG.debug("Mapping file for port %(port)s, %(mapping)s" %
+        LOG.debug("Mapping file for port %(port)s, %(mapping)s",
                   {'port': port.vif_id, 'mapping': mapping})
 
         if not mapping:
@@ -372,8 +372,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         else:
             if (mapping.get('enable_dhcp_optimization', False) and
                'subnets' in mapping):
-                    self._map_dhcp_info(fixed_ips, mapping,
-                                        mapping_dict)
+                self._map_dhcp_info(fixed_ips, mapping, mapping_dict)
         ips_aap = []
 
         def filter_cidr_aaps(aaps):
@@ -487,7 +486,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             nested_domain_dict["interface-name"] = mapping_dict[
                     "interface-name"]
             nested_domain_dict["uuid"] = uuidutils.generate_uuid()
-            LOG.debug("lbiface file for port %(port)s: \n %(mapping)s" %
+            LOG.debug("lbiface file for port %(port)s: \n %(mapping)s",
                       {'port': port.vif_id, 'mapping': nested_domain_dict})
             lbiface_file_name = port.vif_id + '_' + mac
             self._write_lbiface_file(lbiface_file_name, nested_domain_dict)
@@ -503,7 +502,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 nested_domain_dict = nested_domain_dict.copy()
                 nested_domain_dict["interface-name"] = self.uplink_intf_name
                 nested_domain_dict["uuid"] = uuidutils.generate_uuid()
-                LOG.debug("Uplink lbiface file for %(intf)s: \n %(mapping)s" %
+                LOG.debug("Uplink lbiface file for %(intf)s: \n %(mapping)s",
                           {'intf': self.uplink_intf_name,
                            'mapping': nested_domain_dict})
                 self._write_lbiface_file(
@@ -515,7 +514,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 mapping_dict.pop('security-group', None)
 
         # Create one file per MAC address.
-        LOG.debug("Final endpoint file for port %(port)s: \n %(mapping)s" %
+        LOG.debug("Final endpoint file for port %(port)s: \n %(mapping)s",
                   {'port': port.vif_id, 'mapping': mapping_dict})
         file_name = port.vif_id + '_' + mac
         if master_port_id:
@@ -658,7 +657,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 elif key == 'ip6_gateway':
                     nh.ip6_gateway = parse_gateway(value)
             self.ext_seg_next_hop[es_name] = nh
-            LOG.debug("Found external segment: %s" % nh)
+            LOG.debug("Found external segment: %s", nh)
 
     def _fill_ip_mapping_info(self, port_id, port_mac, gbp_details, ips,
                               mapping):

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -211,8 +211,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             self._registered_endpoints.add(port.vif_id)
             self.vif_int_dict.update({port.vif_id: port.port_name})
         except Exception as e:
-            LOG.exception(_("Error while parsing ep file for "
-                            "port %(port)s: %(ex)s"), {'port': port, 'ex': e})
+            LOG.exception("Error while parsing ep file for "
+                          "port %(port)s: %(ex)s", {'port': port, 'ex': e})
 
     def undeclare_endpoint(self, port_id):
         LOG.info("Endpoint undeclare requested for port %s", port_id)
@@ -270,8 +270,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                                 # KeyError should only happen for UT
                                 # EP File would be deleted if parsing fails
                                 # for a VPP endpoint at restart
-                                LOG.exception(_("Error while parsing ep "
-                                    "file %(file)s: %(ex)s"),
+                                LOG.exception("Error while parsing ep "
+                                    "file %(file)s: %(ex)s",
                                     {'file': f, 'ex': e})
 
                     else:
@@ -554,7 +554,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
     def _handle_host_snat_ip(self, host_snat_ips):
         for hsi in host_snat_ips:
-            LOG.debug(_("Auto-allocated host SNAT IP: %s"), hsi)
+            LOG.debug("Auto-allocated host SNAT IP: %s", hsi)
             es = hsi.get('external_segment_name')
             if not es:
                 continue
@@ -576,13 +576,13 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     nh.ip6_gateway = gw
                     updated = True
             else:
-                LOG.info(_("Ignoring invalid auto-allocated SNAT IP %s"), ip)
+                LOG.info("Ignoring invalid auto-allocated SNAT IP %s", ip)
             if updated:
                 # Clear the interface so that SNAT iptables will be
                 # re-created as required; leave MAC as is so that it will
                 # be re-used
                 nh.next_hop_iface = None
-                LOG.info(_("Add/update SNAT info: %s"), nh)
+                LOG.info("Add/update SNAT info: %s", nh)
 
     def _map_dhcp_info(self, fixed_ips, mapping, mapping_dict):
         """ Add DHCP specific info to the EP file."""
@@ -658,7 +658,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 elif key == 'ip6_gateway':
                     nh.ip6_gateway = parse_gateway(value)
             self.ext_seg_next_hop[es_name] = nh
-            LOG.debug(_("Found external segment: %s") % nh)
+            LOG.debug("Found external segment: %s" % nh)
 
     def _fill_ip_mapping_info(self, port_id, port_mac, gbp_details, ips,
                               mapping):
@@ -751,9 +751,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         self.int_fip_pool[ip_ver].remove(fip)
         self.int_fip_alloc[ip_ver].setdefault(
             (port_id, port_mac), {}).setdefault(es, {})[ip] = fip
-        LOG.debug(_("Allocated internal v%(version)d FIP %(fip)s to "
-                    "port %(port)s, %(mac)s, fixed IP %(ip)s "
-                    "in external segment %(es)s"),
+        LOG.debug("Allocated internal v%(version)d FIP %(fip)s to "
+                  "port %(port)s, %(mac)s, fixed IP %(ip)s "
+                  "in external segment %(es)s",
                   {'fip': fip, 'port': port_id, 'mac': port_mac,
                    'es': es, 'ip': ip, 'version': ip_ver})
         return fip
@@ -783,9 +783,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 fips.extend(x.values())
         for float_ip in fips:
             self.int_fip_pool[ip_ver].add(float_ip)
-        LOG.debug(_("Released internal v%(version)d FIP(s) %(fip)s "
-                    "for port %(port)s, mac %(mac)s, "
-                    "fixed IP %(ip)s, external segment %(es)s"),
+        LOG.debug("Released internal v%(version)d FIP(s) %(fip)s "
+                  "for port %(port)s, mac %(mac)s, "
+                  "fixed IP %(ip)s, external segment %(es)s",
                   {'fip': fips, 'port': port_id, 'mac': port_mac or '<all>',
                    'es': es or '<all>', 'ip': ip or '<all>',
                    'version': ip_ver})
@@ -819,8 +819,8 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 self.snat_iptables.cleanup_snat_for_es(es)
                 LOG.debug("Removed SNAT iptables for %s", es)
             except Exception as e:
-                LOG.warn(_("Failed to remove SNAT iptables for "
-                           "%(es)s: %(ex)s"),
+                LOG.warn("Failed to remove SNAT iptables for "
+                         "%(es)s: %(ex)s",
                          {'es': es, 'ex': e})
 
     def _get_next_hop_info_for_es(self, ipm, host_snat_ip_es):
@@ -840,13 +840,13 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                         nh.ip_start, nh.ip_end, nh.ip_gateway,
                         nh.ip6_start, nh.ip6_end, nh.ip6_gateway,
                         nh.next_hop_mac, mtu=self.nat_mtu_size))
-                LOG.info(_("Created SNAT iptables for %(es)s: "
-                           "iface %(if)s, mac %(mac)s"),
+                LOG.info("Created SNAT iptables for %(es)s: "
+                         "iface %(if)s, mac %(mac)s",
                          {'es': es_name, 'if': nh.next_hop_iface,
                           'mac': nh.next_hop_mac})
             except Exception as e:
-                LOG.exception(_("Error while creating SNAT iptables for "
-                                "%(es)s: %(ex)s"),
+                LOG.exception("Error while creating SNAT iptables for "
+                              "%(es)s: %(ex)s",
                               {'es': es_name, 'ex': e})
             self._create_host_endpoint_file(ipm, nh)
         return (nh.next_hop_iface, nh.next_hop_mac)

--- a/opflexagent/utils/ep_managers/endpoint_manager_base.py
+++ b/opflexagent/utils/ep_managers/endpoint_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -13,7 +13,7 @@
 import time
 
 from neutron.agent import rpc as agent_rpc
-from neutron.common import topics
+from neutron_lib.agent import topics
 from neutron_lib import context
 from oslo_log import log as logging
 from oslo_utils import excutils

--- a/opflexagent/utils/port_managers/async_port_manager.py
+++ b/opflexagent/utils/port_managers/async_port_manager.py
@@ -80,9 +80,11 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
         return self
 
     def apply_config(self):
-        LOG.debug("Apply config, pending requests: %s. current responses: "
-                  "%s" % (self.pending_requests._pending_requests_by_device_id,
-                          self.response_by_device_id))
+        LOG.debug("Apply config, pending requests: %(reqs)s. current "
+                  "responses: %(resps)s",
+                  {'reqs':
+                   self.pending_requests._pending_requests_by_device_id,
+                   'resps': self.response_by_device_id})
         skipped = []
         response_by_device_id_copy = self.response_by_device_id
         self.response_by_device_id = {}
@@ -169,7 +171,7 @@ class AsyncPortManager(base.PortManagerBase, rpc.OpenstackRpcMixin):
                 self.response_by_device_id[detail['device']] = detail
             else:
                 LOG.warn("Endpoint update for port %s is malformed "
-                         "(request_id missing)" % detail.get('device'))
+                         "(request_id missing)", detail.get('device'))
             LOG.debug("Got response for port %(port_id)s in "
                       "%(secs)s seconds",
                       {'port_id': detail.get('device'),

--- a/opflexagent/utils/port_managers/port_manager_base.py
+++ b/opflexagent/utils/port_managers/port_manager_base.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import abc
+
 import six
 
 

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -10,11 +10,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from contextlib2 import ExitStack, contextmanager
+from contextlib2 import contextmanager
+from contextlib2 import ExitStack
 from neutron_lib.utils import runtime
+from oslo_log import log as logging
+
 from opflexagent.utils.bridge_managers import (
     bridge_manager_base as bridge_manager)
-from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -31,7 +31,7 @@ def get_bridge_manager(conf):
                 bridge_manager.BRIDGE_MANAGER_NAMESPACE, conf.bridge_manager)
         return loaded_class()
     except ImportError:
-        LOG.error(_("Error loading bridge manager '%s'"),
+        LOG.error("Error loading bridge manager '%s'",
                   conf.bridge_manager)
         raise SystemExit(1)
 

--- a/opflexagent/vif_plug_vpp/exception.py
+++ b/opflexagent/vif_plug_vpp/exception.py
@@ -10,9 +10,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from os_vif.i18n import _
-
 from os_vif import exception as osv_exception
+
+from opflexagent._i18n import _
 
 
 class AgentError(osv_exception.ExceptionBase):

--- a/opflexagent/vif_plug_vpp/vpp.py
+++ b/opflexagent/vif_plug_vpp/vpp.py
@@ -54,14 +54,14 @@ class VppPlugin(plugin.PluginBase):
 
     def describe(self):
         pp_ovs = objects.host_info.HostPortProfileInfo(
-            profile_object_name=
-            objects.vif.VIFPortProfileOpenVSwitch.__name__,
+            profile_object_name=(
+                objects.vif.VIFPortProfileOpenVSwitch.__name__),
             min_version="1.0",
             max_version="1.0",
         )
         pp_ovs_representor = objects.host_info.HostPortProfileInfo(
-            profile_object_name=
-            objects.vif.VIFPortProfileOVSRepresentor.__name__,
+            profile_object_name=(
+                objects.vif.VIFPortProfileOVSRepresentor.__name__),
             min_version="1.0",
             max_version="1.0",
         )

--- a/opflexagent/vpp_plug_firewall.py
+++ b/opflexagent/vpp_plug_firewall.py
@@ -11,11 +11,11 @@
 #    under the License.
 
 import functools
-from os_vif import objects
-from oslo_log import log as logging
 
 from nova.network import model
 import nova.network.os_vif_util as os_vif_util
+from os_vif import objects
+from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 

--- a/opflexagent/vpplib/VPPApi.py
+++ b/opflexagent/vpplib/VPPApi.py
@@ -315,8 +315,8 @@ class VPPApi(object):
 
         # Check for a socket error
         if 'sock_errno' in vint[0]:
-                if vint[0]['sock_errno'] != 0:
-                    return 2, ''
+            if vint[0]['sock_errno'] != 0:
+                return 2, ''
         else:
             return 3, ''
 

--- a/opflexagent/vpplib/hook.py
+++ b/opflexagent/vpplib/hook.py
@@ -11,8 +11,9 @@
 #    under the License.
 import os
 import signal
-import six
 import traceback
+
+import six
 
 # import logging
 # from log import RED, single_line_delim, double_line_delim
@@ -47,7 +48,8 @@ class Hook(object):
         @param api_name: name of the API
         @param api_args: tuple containing the API arguments
         """
-        self.LOG.debug("API: %s (%s)" % (api_name, api_args))
+        self.LOG.debug("API: %(name)s (%(args)s)",
+                       {'name': api_name, 'args': api_args})
 
     # noinspection PyTypeChecker
     def after_api(self, api_name, api_args):
@@ -58,7 +60,8 @@ class Hook(object):
         @param api_args: tuple containing the API arguments
         """
 
-        self.LOG.debug("API: %s (%s)" % (api_name, api_args))
+        self.LOG.debug("API: %(name)s (%(args)s)",
+                       {'name': api_name, 'args': api_args})
 
     def before_cli(self, cli):
         """
@@ -67,7 +70,7 @@ class Hook(object):
 
         @param cli: CLI string
         """
-        self.LOG.debug("CLI: %s" % cli)
+        self.LOG.debug("CLI: %s", cli)
 
     def after_cli(self, cli):
         """

--- a/opflexagent/vpplib/vpp_papi_provider.py
+++ b/opflexagent/vpplib/vpp_papi_provider.py
@@ -9,12 +9,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 from collections import deque
 import fnmatch
-from hook import Hook
 import logging
 import os
 import time
+
+from hook import Hook
 
 # Parse the VPP api json files once and store the object globally
 vpp_jsonfiles = []
@@ -134,7 +136,8 @@ class VppPapiProvider(object):
                     raise Exception(
                         "Unexpected event received: %s, expected: %s" %
                         (type(e).__name__, name))
-                self.LOG.debug("Returning event %s:%s" % (name, e))
+                self.LOG.debug("Returning event %(name)s:%(event)s",
+                               {'name': name, 'event': e})
                 return e
             time.sleep(0)  # yield
         raise Exception("Event did not occur within timeout")
@@ -143,7 +146,8 @@ class VppPapiProvider(object):
         """ Enqueue event in the internal event queue. """
         # FIXME use the name instead of relying on type(e).__name__ ?
         # FIXME #2 if this throws, it is eaten silently, Ole?
-        self.LOG.debug("New event: %s: %s" % (name, event))
+        self.LOG.debug("New event: %(name)s: %(event)s",
+                       {'name': name, 'event': event})
         self._events.append(event)
 
     def connect(self):
@@ -523,7 +527,8 @@ class VppPapiProvider(object):
                          'enable': enable})
 
     def bridge_flags(self, bd_id, is_set, feature_bitmap):
-        """Enable/disable required feature of the bridge domain with defined ID.
+        """
+        Enable/disable required feature of the bridge domain with defined ID.
 
         :param int bd_id: Bridge domain ID.
         :param int is_set: Set to 1 to enable, set to 0 to disable the feature.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,5 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-oslo.serialization>=2.18.0,!=2.19.1  # Apache-2.0
-oslo.utils>=3.33.0  # Apache-2.0
-oslo.i18n>=3.15.3  # Apache-2.0
-oslo.log>=3.36.0  # Apache-2.0
-oslo.config>=5.1.0  # Apache-2.0
-os-vif>=1.7.0,!=1.8.0  # Apache-2.0
-
+os-vif!=1.8.0,>=1.7.0 # Apache-2.0
 pyinotify

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,22 +2,12 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-setuptools>=16.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0  # PSF/ZPL
--e git+https://github.com/openstack/neutron.git@stable/queens#egg=neutron
-hacking<0.11,>=0.10.0
-
-cliff>=2.8.0  # Apache-2.0
-coverage>=4.0,!=4.4  # Apache-2.0
-fixtures>=3.0.0 # Apache-2.0/BSD
-httplib2>=0.7.5
-mock>=2.0 # BSD
-ordereddict
-python-subunit>=0.0.18 # Apache-2.0/BSD
-requests-mock>=1.1 # Apache-2.0
-sphinx>=1.6.2  # BSD
-testrepository>=0.0.18 # Apache-2.0/BSD
-testresources>=0.2.4 # Apache-2.0/BSD
+-e git+https://opendev.org/openstack/neutron.git@stable/queens#egg=neutron
+hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+coverage!=4.4,>=4.0 # Apache-2.0
+testtools>=2.2.0 # MIT
+testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
-testtools>=1.4.0 # MIT
-WebTest>=2.0 # MIT
-oslotest>=1.10.0 # Apache-2.0
+WebTest>=2.0.27 # MIT
+oslotest>=3.2.0 # Apache-2.0
+stestr>=1.0.0 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,12 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
+hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
 
 -e git+https://opendev.org/openstack/neutron.git@stable/queens#egg=neutron
-hacking!=0.13.0,<0.14,>=0.12.0 # Apache-2.0
+
 coverage!=4.4,>=4.0 # Apache-2.0
+flake8-import-order==0.12 # LGPLv3
 testtools>=2.2.0 # MIT
 testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,7 @@
 [tox]
 envlist = py27,py35,pep8
-minversion = 3.4.0
+minversion = 2.3.2
 skipsdist = True
-
-# REVISIT: Requiring the tox-venv tox plugin seems to avoid
-# installation of the latest setuptools version, which is incompatible
-# the 1.0 version of MarkupSafe pinned by
-# https://releases.openstack.org/constraints/upper/queens. This should
-# be removed for rocky and newer, which use newer MarkupSafe versions
-# that have resolved the setuptools incompatibility.
-requires = tox-venv
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -20,7 +12,7 @@ setenv = VIRTUAL_ENV={envdir}
 passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 usedevelop = True
 install_command =
-  pip install {opts} {packages}
+  pip install -U {opts} {packages}
 deps =
   -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
   -r{toxinidir}/requirements.txt
@@ -47,26 +39,22 @@ commands =
 commands = {posargs}
 
 [flake8]
-# E125 continuation line does not distinguish itself from next logical line
 # E126 continuation line over-indented for hanging indent
 # E128 continuation line under-indented for visual indent
-# E129 visually indented line with same indent as next logical line
-# E251 unexpected spaces around keyword / parameter equals
-# E265 block comment should start with ‘# ‘
-# E713 test for membership should be ‘not in’
-# F402 import module shadowed by loop variable
-# F811 redefinition of unused variable
-# F812 list comprehension redefines name from line
-# H104 file contains nothing but comments
-# H237 module is removed in Python 3
-# H305 imports not grouped correctly
-# H307 like imports should be grouped together
-# H401 docstring should not start with a space
-# H402 one line docstring needs punctuation
+# E129 visually indented line with same indent as next logical line - REVISIT
+# E741 ambiguous variable name - REVISIT
+# H404 multi line docstring should start with a summary - REVISIT
 # H405 multi line docstring summary not separated with an empty line
-# H904 Wrap long lines in parentheses instead of a backslash
-# TODO(marun) H404 multi line docstring should start with a summary
-ignore = H202,H302,H301,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H305,H307,H401,H402,H404,H405,H904
+# W504 line break after binary operator - REVISIT
+# W605 invalid escape sequence - REVISIT
+ignore = E126,E128,E129,E741,H401,H404,H405,W504,W605
+# H106: Don’t put vim configuration in source files
+# H203: Use assertIs(Not)None to check for None
+# H204: Use assert(Not)Equal to check for equality
+# H205: Use assert(Greater|Less)(Equal) for comparison
+# H904: Delay string interpolations at logging calls
+enable-extensions = H106,H203,H204,H205,H904
 show-source = true
 builtins = _
 exclude = .venv,.git,.tox,dist,doc,*openstack/common*,*neutron/common*,*lib/python*,*egg,build,tools,.ropeproject,rally-scenarios
+import-order-style = pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,43 @@
 [tox]
-envlist = py27,py33,py36,pep8
-minversion = 1.6
+envlist = py27,py35,pep8
+minversion = 3.4.0
 skipsdist = True
+
+# REVISIT: Requiring the tox-venv tox plugin seems to avoid
+# installation of the latest setuptools version, which is incompatible
+# the 1.0 version of MarkupSafe pinned by
+# https://releases.openstack.org/constraints/upper/queens. This should
+# be removed for rocky and newer, which use newer MarkupSafe versions
+# that have resolved the setuptools incompatibility.
+requires = tox-venv
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
+         OS_LOG_CAPTURE={env:OS_LOG_CAPTURE:true}
+         OS_STDOUT_CAPTURE={env:OS_STDOUT_CAPTURE:true}
+         OS_STDERR_CAPTURE={env:OS_STDERR_CAPTURE:true}
+         PYTHONWARNINGS=default::DeprecationWarning
+passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 usedevelop = True
 install_command =
-  pip install -U -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/queens} {opts} {packages}
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-commands =
-  python setup.py testr --slowest --testr-args='{posargs}'
+  pip install {opts} {packages}
+deps =
+  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/queens}
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
+whitelist_externals = sh
+commands = stestr run {posargs}
 
 [testenv:hashtest]
 setenv = VIRTUAL_ENV={envdir}
 
 [testenv:pep8]
+basepython = python2.7
 commands =
   flake8
 
 [testenv:cover]
+basepython = python2.7
 commands =
   coverage erase
   coverage run -m testtools.run


### PR DESCRIPTION
Enhance compatabilty with newer Neutron branches while maintaining
compatability with stable/queens Neutron, and improve the build/test
process. Highlights include:

* Use definitions from neutron_lib where appropriate.

* Update imports of classes moved from
  neutron.agent.securitygroups_rpc to
  neutron.api.rpc.handlers.securitygroups_rpc.

* Replace RPC callback deprecated subscribe method with register.

* Don't use deprecated oslo_config.MultiConfigParser.

* Remove i18n translation markers from log messages, and update
  remaining ones to properly use oslo.i18n.

* Add "# noqa" to code in the middle of imports to prevent pep8
  failures.

* Eliminate unneeded requirements and test-requirements, and update
  remaining ones to match upstream stable/queens Neutron.

* Use stestr instead of testr to run UTs.

* Specify basepython as python2.7 for pep8 and cover jobs, in case
  python3 version of tox is used.

* Require tox-venv to address incompatability between version 1.0 of
  MarkupSafe pinned by
  https://releases.openstack.org/constraints/upper/queens and recent
  versions of setuptools.

* Run Travis CI pep8 job only on python2.7.

(cherry picked from commit 5f7bf264f3e81e250af88ebe341a57dd45356e17)