### PR TITLE
Revert "Unit tests for endpoint level qos policy"

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -307,7 +307,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
             security_group=[{'policy-space': 'common',
                              'name': 'gbp_default'}],
             qos_policy={'policy-space': 'common',
-                         'name': 'gbp_default'},)
+                        'name': 'gbp_default'},)
+
         port = self._port()
         self.manager.declare_endpoint(port, mapping)
 
@@ -335,7 +336,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                    'security-group': [{'policy-space': 'common',
                                        'name': 'gbp_default'}],
                    'qos-policy': {'policy-space': 'common',
-                                   'name': 'gbp_default'}}
+                                  'name': 'gbp_default'}}
         lbiface_file = {
                    "interface-name": 'qpi',
                    "uuid": mock.ANY,
@@ -837,9 +838,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
                                         security_group=[
                                             {'policy-space': 'common',
                                              'name': 'gbp_default'}],
-                                        qos_policy=
-                                            {'policy-space': 'common',
-                                             'name': 'gbp_default'},   
+                                        qos_policy={'policy-space': 'common',
+                                                    'name': 'gbp_default'},
                                         active_active_aap=True)
         port = self._port()
         self.manager._release_int_fip = mock.Mock()
@@ -859,7 +859,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'gbp_default'}])
         self.assertEqual(ep_file['qos-policy'],
                          {'policy-space': 'common',
-                           'name': 'gbp_default'})
+                          'name': 'gbp_default'})
         self.assertTrue(ep_file['active-active-aap'])
 
     def test_dns_domain(self):

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -307,8 +307,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
             security_group=[{'policy-space': 'common',
                              'name': 'gbp_default'}],
             qos_policy={'policy-space': 'common',
-                        'name': 'gbp_default'},)
-
+                         'name': 'gbp_default'},)
         port = self._port()
         self.manager.declare_endpoint(port, mapping)
 
@@ -336,7 +335,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                    'security-group': [{'policy-space': 'common',
                                        'name': 'gbp_default'}],
                    'qos-policy': {'policy-space': 'common',
-                                  'name': 'gbp_default'}}
+                                   'name': 'gbp_default'}}
         lbiface_file = {
                    "interface-name": 'qpi',
                    "uuid": mock.ANY,
@@ -838,8 +837,9 @@ class TestEndpointFileManager(base.OpflexTestBase):
                                         security_group=[
                                             {'policy-space': 'common',
                                              'name': 'gbp_default'}],
-                                        qos_policy={'policy-space': 'common',
-                                                    'name': 'gbp_default'},
+                                        qos_policy=
+                                            {'policy-space': 'common',
+                                             'name': 'gbp_default'},   
                                         active_active_aap=True)
         port = self._port()
         self.manager._release_int_fip = mock.Mock()
@@ -859,7 +859,7 @@ class TestEndpointFileManager(base.OpflexTestBase):
                            'name': 'gbp_default'}])
         self.assertEqual(ep_file['qos-policy'],
                          {'policy-space': 'common',
-                          'name': 'gbp_default'})
+                           'name': 'gbp_default'})
         self.assertTrue(ep_file['active-active-aap'])
 
     def test_dns_domain(self):

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -305,7 +305,9 @@ class TestEndpointFileManager(base.OpflexTestBase):
             nested_domain_allowed_vlans=[2, 3, 4],
             nested_host_vlan=4094,
             security_group=[{'policy-space': 'common',
-                             'name': 'gbp_default'}],)
+                             'name': 'gbp_default'}],
+            qos_policy={'policy-space': 'common',
+                         'name': 'gbp_default'},)
         port = self._port()
         self.manager.declare_endpoint(port, mapping)
 
@@ -331,7 +333,9 @@ class TestEndpointFileManager(base.OpflexTestBase):
                    "attestation": [],
                    'policy-space-name': 'apic_tenant',
                    'security-group': [{'policy-space': 'common',
-                                       'name': 'gbp_default'}]}
+                                       'name': 'gbp_default'}],
+                   'qos-policy': {'policy-space': 'common',
+                                   'name': 'gbp_default'}}
         lbiface_file = {
                    "interface-name": 'qpi',
                    "uuid": mock.ANY,
@@ -833,6 +837,9 @@ class TestEndpointFileManager(base.OpflexTestBase):
                                         security_group=[
                                             {'policy-space': 'common',
                                              'name': 'gbp_default'}],
+                                        qos_policy=
+                                            {'policy-space': 'common',
+                                             'name': 'gbp_default'},   
                                         active_active_aap=True)
         port = self._port()
         self.manager._release_int_fip = mock.Mock()
@@ -850,6 +857,9 @@ class TestEndpointFileManager(base.OpflexTestBase):
         self.assertEqual(ep_file['security-group'],
                          [{'policy-space': 'common',
                            'name': 'gbp_default'}])
+        self.assertEqual(ep_file['qos-policy'],
+                         {'policy-space': 'common',
+                           'name': 'gbp_default'})
         self.assertTrue(ep_file['active-active-aap'])
 
     def test_dns_domain(self):

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -450,6 +450,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         if 'security_group' in mapping:
             mapping_dict['security-group'] = mapping['security_group']
 
+        if 'qos_policy' in mapping:
+            mapping_dict['qos-policy'] = mapping['qos_policy']
+
         nested_domain_dict = {}
         allowed_vlans = []
         if 'nested_domain_name' in mapping and mapping['nested_domain_name']:


### PR DESCRIPTION
Reverts noironetworks/python-opflex-agent#411