### PR TITLE
Fix python3 bugs

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -832,6 +832,11 @@ class TestEndpointFileManager(base.OpflexTestBase):
                                                   'ip_version': 4,
                                                   'dns_nameservers': [],
                                                   'cidr': '192.168.0.0/24',
+                                                  'dhcp_server_ports': {
+                                                      'fa:16:3e:a7:a3:aa': [
+                                                          '192.168.0.2'
+                                                      ]
+                                                  },
                                                   'host_routes': []}],
                                         dhcp_lease_time=100,
                                         security_group=[
@@ -1204,3 +1209,24 @@ class TestEndpointFileManager(base.OpflexTestBase):
 
     def test_dhcp_ep_no_svi(self):
         self._test_dhcp_ep()
+
+    def test_snat_to_fip(self):
+        """Test mapping between host snat ips to floating ips."""
+        self.manager.snat_iptables.setup_snat_for_es.return_value = tuple(
+            ['foo-if', 'foo-mac'])
+        mapping = self._get_gbp_details(floating_ip=[])
+        port_1 = self._port()
+        self.manager.declare_endpoint(port_1, mapping)
+
+        mapping['host_snat_ips'] = []
+        mapping = self._get_gbp_details(host_snat_ips=[],
+            ip_mapping=[],
+            floating_ip=[{'id': '2',
+                          'floating_ip_address': '172.10.0.2',
+                          'floating_network_id': 'ext_net',
+                          'router_id': 'ext_rout',
+                          'port_id': 'port_id',
+                          'fixed_ip_address': '192.168.0.2',
+                          'nat_epg_name': 'EXT-1',
+                          'nat_epg_tenant': 'nat-epg-tenant'}])
+        self.manager.declare_endpoint(port_1, mapping)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -618,7 +618,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 # IP, so just use the first IP from the first entry in
                 # the dict. Once the agent supports additional IPs, we
                 # can provide the full dict.
-                dhcp_mac = sn['dhcp_server_ports'].keys()[0]
+                dhcp_mac = list(sn['dhcp_server_ports'].keys())[0]
                 dhcp4['server-mac'] = dhcp_mac
                 dhcp4['server-ip'] = sn['dhcp_server_ports'][dhcp_mac][0]
             if 'interface_mtu' in mapping:
@@ -728,7 +728,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
         for ip_ver in es_using_int_fip.keys():
             fip_alloc = self._get_int_fips(ip_ver, port_id, port_mac)
-            for es in fip_alloc.keys():
+            for es in list(fip_alloc.keys()):
                 if es not in es_using_int_fip[ip_ver]:
                     self._release_int_fip(ip_ver, port_id, port_mac, es)
                 else:


### PR DESCRIPTION
There are a couple of bugs that happened as part of the effort to
support both python2 and python3. In python3, the object returned
from a dictionary "keys" or "values" method isn't a list, but is
instead an iterable that behaves more like a set (can't index it
like you can an array). As a result, code that attempts to index
this fails. The solution is to convert the returned object to a
list. The second issue is that exceptions are now thrown when a
list that is iterated on changes during the iteration. The fix
for this is to also create a new list object.