### PR TITLE
Replace backslash in VM names with pipe

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1128,6 +1128,18 @@ class TestEndpointFileManager(base.OpflexTestBase):
         mapping['endpoint_group_name'] = None
         self.manager.declare_endpoint(port_1, mapping)
 
+    def test_vm_name_sanitization(self):
+        mapping = self._get_gbp_details()
+        port_1 = self._port()
+
+        # Use VM name with backslashes, which should be
+        # converted to avoid interpreting the name as a DN
+        mapping['vm-name'] = 'some/vm/name/here'
+        self.manager.declare_endpoint(port_1, mapping)
+        epargs = self.manager._write_endpoint_file.call_args_list
+        ep_file_vm_name = epargs[1][0][1].get('attributes').get('vm-name')
+        self.assertFalse("/" in ep_file_vm_name)
+
     def _test_vlan_net_port_bound(self, svi=False):
         # the SVI related info we expect to see
         # on get_gbp_details

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -423,7 +423,11 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         if 'active_active_aap' in mapping:
             mapping_dict['active-active-aap'] = mapping['active_active_aap']
         if 'vm-name' in mapping:
-            mapping_dict['attributes'] = {'vm-name': mapping['vm-name']}
+            # ACI interprets backslash characters as part of a DN.
+            # To avoid this, convert all backslash characters to
+            # pipe characters.
+            sanitized_vm_name = mapping['vm-name'].replace("/", "|")
+            mapping_dict['attributes'] = {'vm-name': sanitized_vm_name}
         if 'vrf_name' in mapping:
             mapping_dict['domain-policy-space'] = mapping['vrf_tenant']
             mapping_dict['domain-name'] = mapping['vrf_name']


### PR DESCRIPTION
OpenStack allows backslash characters in VM names. Unfortunately,
APIC interprets the backslash in a VM name as part of a Distinguished
Name (DN), which makes the name invalid. In order to avoid this
incompatibility, replace backslashes ("/") with a pipe ("|") when
creating endpoint files.

(cherry picked from commit 180437fd4f940f5877f758a3695aecdd5fb35e98)
(cherry picked from commit 93d684d27ed5a36747332ada3f4b2701ab4245f7)
(cherry picked from commit 42f9a31d1896c6dbf5680963ff47a17d05902105)
(cherry picked from commit 5d7e691157a2dec937278149b8186e2d042a24b3)
(cherry picked from commit 3004393932d45a2dae1212f729404abbfc72502b)
(cherry picked from commit d8d079109f4f426fd074b150aa535232d1fe0baa)