### PR TITLE
Fix MD5 encoding

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -312,7 +312,7 @@ class EpWatcher(FileWatcher):
 
     def gen_domain_uuid(self, tenant, name):
         fqname = '%s|%s' % (tenant, name)
-        fqhash = hashlib.md5(fqname).hexdigest()
+        fqhash = hashlib.md5(fqname.encode('utf-8')).hexdigest()
         fquuid = str(uuid.UUID(fqhash))
         return fquuid
 

--- a/opflexagent/snat_iptables_manager.py
+++ b/opflexagent/snat_iptables_manager.py
@@ -111,7 +111,7 @@ class SnatIptablesManager(object):
 
     def _get_hash_for_es(self, es_name):
         return ("%s%s" % (self.IFACE_PREFIX,
-                          hashlib.md5(es_name).hexdigest()[:12]))
+            hashlib.md5(es_name.encode('utf-8')).hexdigest()[:12]))
 
     def setup_snat_for_es(self, es_name,
                           ip_start=None, ip_end=None, ip_gw=None,

--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+from neutron.tests import base
+
+from opflexagent import as_metadata_manager
+
+TEST_TENANT = 'some_tenant'
+TEST_NAME = 'some_name'
+HASH_RESULT = 'a6cb6f24-92d6-31b5-21e6-25b41c0fddc1'
+
+
+class TestEpWatcher(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestEpWatcher, self).setUp()
+
+    def test_hash(self):
+        with mock.patch('opflexagent.as_metadata_manager.FileProcessor.run'):
+            self.watcher = as_metadata_manager.EpWatcher()
+            hash = self.watcher.gen_domain_uuid(TEST_TENANT, TEST_NAME)
+            self.assertEqual(hash, HASH_RESULT)

--- a/opflexagent/test/test_snat_mgr.py
+++ b/opflexagent/test/test_snat_mgr.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from neutron.tests import base
+
+from opflexagent import snat_iptables_manager
+
+TEST_HASH_STRING = 'a_test_hash_string'
+HASH_RESULT = 'of-dd6bf9992ab0'
+
+
+class TestSnatManager(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestSnatManager, self).setUp()
+        self.mgr = snat_iptables_manager.SnatIptablesManager(None)
+
+    def test_hash_for_es(self):
+        hash = self.mgr._get_hash_for_es(TEST_HASH_STRING)
+        self.assertEqual(hash, HASH_RESULT)


### PR DESCRIPTION
For python3, the MD5 hash uses bytes, not characters.

(cherry picked from commit 3617f1b2b82b2313cabbd351dcb528068c3491f0)