### PR TITLE
Fix topology agent

### DIFF
--- a/opflexagent/apic_topology.py
+++ b/opflexagent/apic_topology.py
@@ -278,8 +278,10 @@ class ApicTopologyAgent(manager.Manager):
 
 def launch(binary, manager, topic=None):
     cfg.CONF(project='neutron')
+    config.register_root_helper(cfg.CONF)
     common_cfg.init(sys.argv[1:])
     config.setup_logging()
+    config.setup_privsep()
     report_period = cfg.CONF.apic_host_agent.apic_agent_report_interval
     poll_period = cfg.CONF.apic_host_agent.apic_agent_poll_interval
     server = service.Service.create(


### PR DESCRIPTION
The topology agent was being run without rootwrap and privsep. These
are needed in order to support the lldpctl executable, which requires
root privileges.

(cherry picked from commit 2910ef0c1fc808e61095043bae890c1d6aa5f128)
(cherry picked from commit a974fc4238a1a29be2483d0c0e28c61bf0d7233f)
(cherry picked from commit 2bde0e8bd95188bdbf9f72fabc3a98b36f7e1116)