### PR TITLE
Fix contextlib2 dependency

### DIFF
--- a/opflexagent/test/base.py
+++ b/opflexagent/test/base.py
@@ -9,8 +9,25 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from contextlib2 import contextmanager
+from contextlib2 import ExitStack
 
 from neutron.tests import base
+
+
+@contextmanager
+def nested_context_manager(*contexts):
+    """
+    The new Python 3 contextlib.ExitStack class was
+    added as a replacement for contextlib.nested()
+    Used to combine other context managers.
+
+    :param contexts: list of context managers
+    """
+    with ExitStack() as stack:
+        for ctx in contexts:
+            stack.enter_context(ctx)
+        yield contexts
 
 
 class OpflexTestBase(base.BaseTestCase):

--- a/opflexagent/test/test_agent_types.py
+++ b/opflexagent/test/test_agent_types.py
@@ -14,7 +14,6 @@ import mock
 
 from opflexagent import gbp_agent
 from opflexagent.test import base
-from opflexagent.utils import utils
 
 from oslo_config import cfg
 
@@ -44,7 +43,7 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             mock.patch('os.path.basename'),
             mock.patch('sys.argv')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             gbp_agent.main()
             self.assertEqual(1, opflex_patch.call_count)
             self.assertEqual(1, metadata_patch.call_count)
@@ -62,7 +61,7 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             mock.patch('os.path.basename'),
             mock.patch('sys.argv')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             gbp_agent.main()
             self.assertEqual(1, import_patch.call_count)
             self.assertEqual(
@@ -80,7 +79,7 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             mock.patch('os.path.basename'),
             mock.patch('sys.argv')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             gbp_agent.main()
             self.assertEqual(1, import_patch.call_count)
             self.assertEqual(
@@ -98,7 +97,7 @@ class TestGBPOpflexAgentTypes(base.OpflexTestBase):
             mock.patch('sys.argv'),
         ]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             with mock.patch('sys.exit') as sys_patch:
                 try:
                     gbp_agent.main()

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -21,7 +21,6 @@ from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager
 from opflexagent.test import base
 from opflexagent.utils.ep_managers import endpoint_file_manager
-from opflexagent.utils import utils
 
 from neutron.api.rpc.callbacks import events
 from neutron.conf.agent import dhcp as dhcp_config
@@ -106,7 +105,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             mock.patch('opflexagent.gbp_agent.GBPOpflexAgent.'
                 '_report_state')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             agent = gbp_agent.GBPOpflexAgent(**kwargs)
             # set back to true because initial report state will succeed due
             # to mocked out RPC calls
@@ -311,7 +310,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                     'undeclare_endpoint'),
             mock.patch.object(ovs.OVSPluginApi, 'update_device_down')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             port_stats = {'regular': {'added': 0,
                                       'updated': 0,
                                       'removed': 0},
@@ -337,7 +336,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                     'undeclare_endpoint'),
             mock.patch.object(ovs.OVSPluginApi, 'update_device_down')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             agent = self._initialize_agent()
             self._mock_agent(agent)
             port_info = {'current': set(['1', '2']),

--- a/opflexagent/test/test_gbp_vpp_agent.py
+++ b/opflexagent/test/test_gbp_vpp_agent.py
@@ -28,7 +28,6 @@ from opflexagent import gbp_agent
 from opflexagent import snat_iptables_manager
 from opflexagent.test import base
 from opflexagent.utils.ep_managers import endpoint_file_manager
-from opflexagent.utils import utils
 from oslo_config import cfg
 from oslo_utils import uuidutils
 
@@ -100,7 +99,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             mock.patch('opflexagent.gbp_agent.GBPOpflexAgent.'
                 '_report_state')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             agent = gbp_agent.GBPOpflexAgent(**kwargs)
             # set back to true because initial report state will succeed due
             # to mocked out RPC calls
@@ -299,7 +298,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                     'undeclare_endpoint'),
             mock.patch.object(ovs.OVSPluginApi, 'update_device_down')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             port_stats = {'regular': {'added': 0,
                                       'updated': 0,
                                       'removed': 0},
@@ -326,7 +325,7 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
                 ovs.OVSPluginApi,
                 'update_device_down')]
 
-        with utils.nested_context_manager(*resources):
+        with base.nested_context_manager(*resources):
             agent = self._initialize_agent()
             self._mock_agent(agent)
             port_info = {'current': set(['1', '2']),

--- a/opflexagent/utils/utils.py
+++ b/opflexagent/utils/utils.py
@@ -10,8 +10,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from contextlib2 import contextmanager
-from contextlib2 import ExitStack
 from neutron_lib.utils import runtime
 from oslo_log import log as logging
 
@@ -36,18 +34,3 @@ def get_bridge_manager(conf):
         LOG.error("Error loading bridge manager '%s'",
                   conf.bridge_manager)
         raise SystemExit(1)
-
-
-@contextmanager
-def nested_context_manager(*contexts):
-    """
-    The new Python 3 contextlib.ExitStack class was
-    added as a replacement for contextlib.nested()
-    Used to combine other context managers.
-
-    :param contexts: list of context managers
-    """
-    with ExitStack() as stack:
-        for ctx in contexts:
-            stack.enter_context(ctx)
-        yield contexts


### PR DESCRIPTION
The contextlib2 package is only needed for unit tests. Move the
helper method to the base test class, so that we don't have to
depend on this package in distributions.

(cherry picked from commit d96dd70904755313682a188d9d113419e569efbc)
(cherry picked from commit 12e744a364413f4d51a1b1c70a6bc3fa03cdcbc1)