### PR TITLE
Fix python3 bugs

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -622,7 +622,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                 # IP, so just use the first IP from the first entry in
                 # the dict. Once the agent supports additional IPs, we
                 # can provide the full dict.
-                dhcp_mac = sn['dhcp_server_ports'].keys()[0]
+                dhcp_mac = list(sn['dhcp_server_ports'].keys())[0]
                 dhcp4['server-mac'] = dhcp_mac
                 dhcp4['server-ip'] = sn['dhcp_server_ports'][dhcp_mac][0]
             if 'interface_mtu' in mapping:
@@ -732,7 +732,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
         for ip_ver in es_using_int_fip.keys():
             fip_alloc = self._get_int_fips(ip_ver, port_id, port_mac)
-            for es in fip_alloc.keys():
+            for es in list(fip_alloc.keys()):
                 if es not in es_using_int_fip[ip_ver]:
                     self._release_int_fip(ip_ver, port_id, port_mac, es)
                 else:


### PR DESCRIPTION
There are a couple of bugs that happened as part of the effort to
support both python2 and python3. In python3, the object returned
from a dictionary "keys" or "values" method isn't a list, but is
instead an iterable that behaves more like a set (can't index it
like you can an array). As a result, code that attempts to index
this fails. The solution is to convert the returned object to a
list. The second issue is that exceptions are now thrown when a
list that is iterated on changes during the iteration. The fix
for this is to also create a new list object.

(cherry picked from commit d4dbf6bd6db9c1f519088fecf82f88ccf9599950)