### PR TITLE
Fix list iteration bug for python3

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1226,19 +1226,22 @@ class TestEndpointFileManager(base.OpflexTestBase):
         """Test mapping between host snat ips to floating ips."""
         self.manager.snat_iptables.setup_snat_for_es.return_value = tuple(
             ['foo-if', 'foo-mac'])
-        mapping = self._get_gbp_details(floating_ip=[])
         port_1 = self._port()
+        mapping = self._get_gbp_details(port_id=port_1.vif_id,
+                                        floating_ip=[])
         self.manager.declare_endpoint(port_1, mapping)
 
         mapping['host_snat_ips'] = []
-        mapping = self._get_gbp_details(host_snat_ips=[],
+        mapping = self._get_gbp_details(port_id=port_1.vif_id,
+                                        host_snat_ips=[],
             ip_mapping=[],
             floating_ip=[{'id': '2',
                           'floating_ip_address': '172.10.0.2',
                           'floating_network_id': 'ext_net',
                           'router_id': 'ext_rout',
-                          'port_id': 'port_id',
+                          'port_id': port_1.vif_id,
                           'fixed_ip_address': '192.168.0.2',
                           'nat_epg_name': 'EXT-1',
                           'nat_epg_tenant': 'nat-epg-tenant'}])
         self.manager.declare_endpoint(port_1, mapping)
+        self.manager.undeclare_endpoint(port_1.vif_id)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -779,7 +779,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     (port_id, port_mac), {}).values()
             else:
                 fip_map_list = []
-                for id_mac in self.int_fip_alloc[ip_ver].keys():
+                for id_mac in list(self.int_fip_alloc[ip_ver].keys()):
                     if id_mac[0] == port_id:
                         fip_map_list.extend(
                             self.int_fip_alloc[ip_ver].pop(


### PR DESCRIPTION
An exception is thrown in python3 when a list that is iterated on
changes during the iteration. The fix for this is to also create a
new list object.