### PR TITLE
Fix opflex notify socket communication

### DIFF
--- a/opflexagent/opflex_notify.py
+++ b/opflexagent/opflex_notify.py
@@ -79,7 +79,7 @@ class OpflexNotifyAgent(object):
                         ],
                     },
                 }
-                msg = bytearray(json.dumps(subscribe))
+                msg = bytearray(json.dumps(subscribe).encode('utf-8'))
                 msg_len = socket.htonl(len(msg))
                 client.send(struct.pack('I', msg_len))
                 client.send(msg)
@@ -110,7 +110,7 @@ class OpflexNotifyAgent(object):
                 raise ValueError('Unexpected message length {} (msg_len {})'.
                     format(len(msg), msg_len))
 
-            notif = json.loads(msg)
+            notif = json.loads(msg.decode('utf-8'))
             if ('method' not in notif or 'params' not in notif):
                 raise ValueError('Unexpected message {}'.format(notif))
 

--- a/opflexagent/test/test_opflex_notify.py
+++ b/opflexagent/test/test_opflex_notify.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2020 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import socket
+import struct
+
+import mock
+
+from neutron.tests import base
+from oslo_config import cfg
+
+from opflexagent import opflex_notify
+
+
+class TestOpflexNotify(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestOpflexNotify, self).setUp()
+        # Configure the Cisco APIC mechanism driver
+        cfg.CONF.set_override('opflex_notify_socket_path',
+                              '/the/path', 'OPFLEX')
+
+    def test_notify_socket(self):
+        """Verify message encoding and decoding is done properly."""
+        msg = {'method': 'virtual-ip',
+               'params': {
+                   'uuid': 'foo',
+                   'mac': 'bar',
+                   'ip': '192.168.0.1'}}
+        encoded_msg = bytearray(json.dumps(msg).encode('utf-8'))
+        with mock.patch('os.path.exists') as mock_path:
+            mock_path.return_value = True
+            with mock.patch('socket.socket') as socket_create:
+                self.agent = opflex_notify.OpflexNotifyAgent()
+                self.agent._connect()
+                socket_create.assert_has_calls([
+                    mock.call(socket.AF_UNIX, socket.SOCK_STREAM),
+                    mock.call().connect('/the/path'),
+                    mock.call().send(b'\x00\x00\x00;'),
+                    mock.call().send(bytearray(b'{"method": "subscribe", '
+                                               b'"params": {'
+                                               b'"type": ["virtual-ip"]}}'))]
+                )
+                socket_create.reset_mock()
+                socket_create.recv.side_effect = (
+                    struct.pack('I',
+                        socket.htonl(len(encoded_msg))), encoded_msg,)
+                read_msg = self.agent._read_msg(socket_create)
+                socket_create.assert_has_calls([
+                    mock.call.recv(4),
+                    mock.call.recv(len(encoded_msg))]
+                )
+                self.assertEqual(read_msg, ('foo', 'bar', '192.168.0.1'))


### PR DESCRIPTION
Operations with sockets use bytes, not characters. This patch adds
conversions to ensure proper handling. It also adds a UT for
verification.

(cherry picked from commit 9c470b068a422eab4b5dd60ccf5771d677411104)
(cherry picked from commit 38f5f9350d5b2b8bde9d0cad06a24fd4f7326764)
(cherry picked from commit d1289eba031058b7e2b01e66776712d0bc977efa)
(cherry picked from commit aec702819f4ee0fb4ee01bea5746293ab9b02f58)