### PR TITLE
Fix opflex notify UT

### DIFF
--- a/opflexagent/test/test_opflex_notify.py
+++ b/opflexagent/test/test_opflex_notify.py
@@ -41,6 +41,9 @@ class TestOpflexNotify(base.BaseTestCase):
                    'mac': 'bar',
                    'ip': '192.168.0.1'}}
         encoded_msg = bytearray(json.dumps(msg).encode('utf-8'))
+        connect_msg = bytearray(json.dumps(
+            {"method": "subscribe",
+             "params": {"type": ["virtual-ip"]}}).encode('utf-8'))
         with mock.patch('os.path.exists') as mock_path:
             mock_path.return_value = True
             with mock.patch('socket.socket') as socket_create:
@@ -50,9 +53,7 @@ class TestOpflexNotify(base.BaseTestCase):
                     mock.call(socket.AF_UNIX, socket.SOCK_STREAM),
                     mock.call().connect('/the/path'),
                     mock.call().send(b'\x00\x00\x00;'),
-                    mock.call().send(bytearray(b'{"method": "subscribe", '
-                                               b'"params": {'
-                                               b'"type": ["virtual-ip"]}}'))]
+                    mock.call().send(connect_msg)]
                 )
                 socket_create.reset_mock()
                 socket_create.recv.side_effect = (


### PR DESCRIPTION
The check for mock call args was failing for python27, due to the
fact that the ordering of the dictionary members was different from
the original message. This patch fixes the UT by ensuring that the
same ordering is used for the check as the encoding.

(cherry picked from commit a6d7128eee9c55b989f752137919a8bf1ee48c01)
(cherry picked from commit b01b102101707141e96ba5de30f7e5c86bfff1b4)
(cherry picked from commit 5aafb9b970df412554f0e01bcd8e4071586ddc14)
(cherry picked from commit fd83c6f1629bd57ecb76015aedfe47508c9143d3)