### PR TITLE
Fixes for python2/3 compatibility

### DIFF
--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -12,9 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import json
+
 import httplib2
 from oslo_config import cfg
 from oslo_log import log as logging
+import setproctitle
 import six
 import six.moves.urllib.parse as urlparse
 import webob
@@ -24,7 +27,6 @@ from neutron.agent.linux import utils as agent_utils
 from neutron.common import config
 from neutron.common import utils
 from neutron import wsgi
-from oslo_serialization import jsonutils
 
 from opflexagent._i18n import _
 
@@ -72,7 +74,7 @@ class NetworkMetadataProxyHandler(object):
         nets = None
         try:
             with open(fqfn, "r") as f:
-                nets = jsonutils.load(f)
+                nets = json.load(f)
         except Exception as e:
             LOG.warning("Exception in reading file: %s", str(e))
 
@@ -155,6 +157,7 @@ class ProxyDaemon(daemon.Daemon):
         self.host = host
 
     def run(self):
+        self._parent_proctitle = setproctitle.getproctitle()
         handler = NetworkMetadataProxyHandler(
             self.network_id,
             self.router_id,

--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -22,6 +22,8 @@ from opflexagent import as_metadata_manager
 TEST_TENANT = 'some_tenant'
 TEST_NAME = 'some_name'
 HASH_RESULT = 'a6cb6f24-92d6-31b5-21e6-25b41c0fddc1'
+JSON_DATA = {"foo": "bar"}
+JSON_FILE_DATA = '{"foo": "bar"}'
 
 
 class TestEpWatcher(base.BaseTestCase):
@@ -34,3 +36,22 @@ class TestEpWatcher(base.BaseTestCase):
             self.watcher = as_metadata_manager.EpWatcher()
             hash = self.watcher.gen_domain_uuid(TEST_TENANT, TEST_NAME)
             self.assertEqual(hash, HASH_RESULT)
+
+    def test_read_json_file(self):
+        with mock.patch('builtins.open',
+                new=mock.mock_open(read_data=JSON_FILE_DATA)) as open_file:
+            data = as_metadata_manager.read_jsonfile('foo')
+            open_file.assert_called_once_with('foo', 'r')
+            self.assertEqual(data, JSON_DATA)
+
+    def test_write_json_file(self):
+        with mock.patch('builtins.open') as open_file:
+            as_metadata_manager.write_jsonfile('foo', JSON_DATA)
+            open_file.assert_called_once_with('foo', 'w')
+            write_list = []
+            for mc in open_file.mock_calls:
+                if 'write' in str(mc):
+                    write_data = str(mc).split('write')[1][2:-2]
+                    write_list.append(write_data)
+            write_string = ''.join(write_list)
+            self.assertEqual(write_string, JSON_FILE_DATA)


### PR DESCRIPTION
Some python APIs switch from strings to bytes between python2 and
python3. This patch fixes the handling for those, and adds a fix
for a missing object member.

(cherry picked from commit fb21f76315084956dd3ba8abda322fd27f56c210)
(cherry picked from commit bea0f45a667fecab3fb746293dc3b5948c43ccfd)
(cherry picked from commit fe9894d544ef1dc6c5f4a074a11d130b4c8e8cc5)