### PR TITLE
Fix trunk workflow

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -1116,14 +1116,14 @@ class TestEndpointFileManager(base.OpflexTestBase):
         ep_file['uuid'] = port.vif_id + '|aa-bb-cc-00-11-22'
         ep_name = master_port_id + '_sub1_' + mapping['mac_address']
         ep_file['access-interface-vlan'] = 100
-        old_method = self.manager.bridge_manager.get_port_vif_name
 
-        def get_port_vif_name(vif_id):
+        def new_get_port_vif_name(vif_id):
             return 'tap' + vif_id[6:]
-        self.manager.bridge_manager.get_port_vif_name = get_port_vif_name
-        self.manager.declare_endpoint(port, mapping)
-        self.manager._write_endpoint_file.assert_called_with(ep_name, ep_file)
-        self.manager.bridge_manager.get_port_vif_name = old_method
+        with mock.patch.object(self.manager.bridge_manager,
+                               'get_port_vif_name', new=new_get_port_vif_name):
+            self.manager.declare_endpoint(port, mapping)
+            self.manager._write_endpoint_file.assert_called_with(ep_name,
+                                                                 ep_file)
 
     def test_bad_mapping(self):
         mapping = self._get_gbp_details()

--- a/opflexagent/utils/bridge_managers/ovs_lib.py
+++ b/opflexagent/utils/bridge_managers/ovs_lib.py
@@ -19,6 +19,10 @@ from neutron.plugins.ml2.drivers.openvswitch.agent.common import config
 from opflexagent import config  # noqa
 
 
+INVALID_OFPORT = ovs_lib.INVALID_OFPORT
+UNASSIGNED_OFPORT = ovs_lib.UNASSIGNED_OFPORT
+
+
 class OVSBridge(ovs_lib.OVSBridge):
 
     def __init__(self, *args, **kwargs):

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -117,9 +117,11 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
 
     def get_port_vif_name(self, port_id, bridge=None):
         bridge = bridge or self.int_br
-        ports = bridge.get_vifs_by_ids([port_id])
-        if ports:
-            return ports[port_id].port_name
+        all_ports = bridge.get_vif_ports(
+            ofport_filter=(ovs_lib.INVALID_OFPORT, ovs_lib.UNASSIGNED_OFPORT))
+        for port in all_ports:
+            if port.vif_id == port_id:
+                return port.port_name
 
     def get_patch_port_pair_names(self, port_id):
         return (("qpi%s" % port_id)[:NIC_NAME_LEN],


### PR DESCRIPTION
The trunk port workflow would find the wrong interface connected
to an OVS bridge in some cases, due to the reuse of the iface-id
value for patch ports. This patch closes that bug by ensuring that
the VIF selected is qualified by the "attached-mac" property.

(cherry picked from commit c174270758639b911e0a2da0c6778149a1f889ac)
(cherry picked from commit e52debe00ce84bc30d520f51615070625db11afe)
(cherry picked from commit 3f4e6dfaaf6fa8451c8fa6edf9e8b3630f74ec8f)
(cherry picked from commit 49737f27908bf2edd7e5e2eb7826f42aaa37a8d4)
(cherry picked from commit f2d961f053aa9f898ec729b90caf1c6511cafaf9)