### PR TITLE
Remove Python3.5 from stable/queens Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ matrix:
     - python: 2.7
       env:
         - TOX_ENV=pep8
-    - python: 3.5
-      env:
-        - TOX_ENV=py35
 
 install:
   - pip install tox


### PR DESCRIPTION
We currently aren't shipping python3 packages for stable/queens,
so remove it from Travis CI for now (also, it's failing due to
a dependency issue for upstream neutron for python3.5).