### PR TITLE
Fix test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 hacking>=1.1.0,<1.2.0 # Apache-2.0
 
--e git+https://opendev.org/openstack/neutron.git@stable/ussuri#egg=neutron
+neutron
 
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0


### PR DESCRIPTION
Rely on constraints from upstream openstack to pick the correct
version of neutron (validation was failing when specifying it
explicitly).