### PR TITLE
Eliminate temporary OpenStack SNAT traffic interruption after opflex agent restart

### DIFF
--- a/opflexagent/test/base.py
+++ b/opflexagent/test/base.py
@@ -96,6 +96,7 @@ class OpflexTestBase(base.BaseTestCase):
                                    'nat_epg_name': 'nat-epg-name'}],
                    'host_snat_ips': [{'external_segment_name': 'EXT-1',
                                       'host_snat_ip': '200.0.0.10',
+                                      'host_snat_mac': 'aa:bb:cc:00:11:44',
                                       'gateway_ip': '200.0.0.1',
                                       'prefixlen': 8}],
                    'owned_addresses': ['192.168.0.2'],


### PR DESCRIPTION
We will be using the SNAT port's MAC address as the SNAT namespace mac address. Each time the opflex agent restarts, the SNAT namespace will not be deleted and created again as long as it already exists and its mac address is the same as the mac address of the SNAT port's mac address.