### PR TITLE
[python-opflex-agent] brctl deprecated in stein #1399 (#548) (#550) (…

### DIFF
--- a/etc/gbp-opflex.filters
+++ b/etc/gbp-opflex.filters
@@ -19,4 +19,3 @@ chown:         CommandFilter, chown, root
 rm:            CommandFilter, rm, root
 ovs-vsctl:     CommandFilter, ovs-vsctl, root
 ovs-ofctl:     CommandFilter, ovs-ofctl, root
-brctl:         CommandFilter, brctl, root

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -22,7 +22,6 @@ eventlet_utils.monkey_patch()  # noqa
 
 from neutron.agent.common import ip_lib
 from neutron.agent.common import polling
-from neutron.agent.linux import iptables_firewall
 from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as agent_sg_rpc
 from neutron.api.rpc.handlers import securitygroups_rpc as sg_rpc
@@ -334,29 +333,6 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             # the right method once the redesign is complete.
             self.ep_manager.vrf_info_to_file(details)
 
-    # NOTE(ivar): This method doesn't belong here or anywhere near the Neutron
-    # agent at all: Nova's compute agent creates the hybrid bridge and should
-    # configure it properly. However, because of support/issues/591 we need
-    # to make sure that LB aeging is set to 0.
-    def _set_hybrid_bridge_aeging_to_zero(self, device):
-        # Only execute if IPTables firewall driver is used
-        if isinstance(self.sg_agent.firewall,
-                      iptables_firewall.IptablesFirewallDriver):
-            # From nova.network.model.py
-            NIC_NAME_LEN = 14
-            # Naming convention from nova.virt.libvirt/vif.py
-            br_name = ("qbr" + device)[:NIC_NAME_LEN]
-            cmd = ['brctl', 'setageing', br_name, '0']
-            try:
-                self.sg_agent.firewall.iptables.execute(cmd, run_as_root=True)
-            except RuntimeError as e:
-                with excutils.save_and_reraise_exception() as ctx:
-                    if 'No such device' in e.message:
-                        # No need to rerise, port could be bound somehow else
-                        ctx.reraise = False
-                        LOG.warn("Device %s not found while disabling mac "
-                                 "learning", br_name)
-
     def treat_devices_added_or_updated(self, details):
         """Process added or updated devices
         :param: Port details retrieved from the Neutron server
@@ -369,9 +345,6 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         # the right method once the redesign is complete.
         port = self.bridge_manager.get_vif_port_by_id(device)
         if port:
-            # If the following command fails (RuntimeException) the binding
-            # fails.
-            self._set_hybrid_bridge_aeging_to_zero(device)
             gbp_details = details.get('gbp_details')
             trunk_details = details.get('trunk_details')
             neutron_details = details.get('neutron_details')


### PR DESCRIPTION
…#551) (#552)

* support/issues/1399. Upstream sets the aging.

* removing the imports to fix build

(cherry picked from commit 5295596d09f1710d6b4c817eb98bec7dab318fd5)
(cherry picked from commit 0858ae8bb7f39bd24204d4c26d169559e4533a1e)
(cherry picked from commit 657c94556328af60211727079b01541f24dbaafe)
(cherry picked from commit 6fc26644fe657e6bd93d957a377322878a0dd8e0)