### PR TITLE
Add a new directory in the path of notification socket.

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -56,7 +56,7 @@ gbp_opts = [
                help=_("Set the mode of the agent to be used. Options are: "
                       "'opflex' (default), 'dvs', and 'dvs_no_binding'.")),
     cfg.StrOpt('opflex_notify_socket_path',
-               default='/var/run/opflex-agent-notif.sock',
+               default='/var/run/opflex_notify/opflex-agent-notif.sock',
                help=_("Path of the Opflex notification socket.")),
     cfg.IntOpt('nat_mtu_size', default=0,
                help=_("MTU size of the NAT namespace interface.")),


### PR DESCRIPTION
New path is /var/run/opflex_notify/opflex-agent-notif.sock
This socket is to be shared by neutron_opflex_agent container and opflex_agent container. 
By putting the socket file in a saperate directory inside /var/run, only that directory can be conveniently shared between
the two containers as named volume.