### PR TITLE
Fix supervisord user

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -774,7 +774,6 @@ class AsMetadataManager(object):
             "stopwaitsecs=10",
             "stdout_logfile=NONE",
             "stderr_logfile=NONE",
-            "user=neutron",
             "",
             "[program:opflex-ep-watcher]",
             "command=/usr/bin/opflex-ep-watcher " +
@@ -789,7 +788,6 @@ class AsMetadataManager(object):
             "stopwaitsecs=10",
             "stdout_logfile=NONE",
             "stderr_logfile=NONE",
-            "user=neutron",
             "",
             "[program:opflex-state-watcher]",
             "command=/usr/bin/opflex-state-watcher " +
@@ -804,7 +802,6 @@ class AsMetadataManager(object):
             "stopwaitsecs=10",
             "stdout_logfile=NONE",
             "stderr_logfile=NONE",
-            "user=neutron",
             "",
             "[include]",
             "files = %s/*.proxy %s/*.snat" % (MD_DIR, MD_DIR),


### PR DESCRIPTION
Don't specify a user for the processes created using supervisord.
The user will then be the same as the one that started the container.

(cherry picked from commit 9833e7306f331f63e4b931699828a7abda9aaea8)
(cherry picked from commit 3f7cde2b3a14ef441f5f4daa5d514c19c5d7a4b1)