### PR TITLE
Remove setproctitle

### DIFF
--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -17,7 +17,6 @@ import json
 import httplib2
 from oslo_config import cfg
 from oslo_log import log as logging
-import setproctitle
 import six
 import six.moves.urllib.parse as urlparse
 import webob
@@ -157,7 +156,6 @@ class ProxyDaemon(daemon.Daemon):
         self.host = host
 
     def run(self):
-        self._parent_proctitle = setproctitle.getproctitle()
         handler = NetworkMetadataProxyHandler(
             self.network_id,
             self.router_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 
 os-vif!=1.8.0,>=1.7.0 # Apache-2.0
 pyinotify
-setproctitle


### PR DESCRIPTION
Commit fb21f76315084956dd3ba8abda322fd27f56c210 added setproctitle,
and commit 43e91f3bcc74793feb3fcc01072b27169ae7beaf added it to
the package requirements. This isn't needed in rocky and queens,
and in fact causes problems in those releases for debian packaging.

(cherry picked from commit e965ee5a52bfc0d976c018c4caec8a9d8db5df87)