### PR TITLE
Removal of shell calls

### DIFF
--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -62,3 +62,63 @@ class TestEpWatcher(base.BaseTestCase):
                     write_list.append(write_data)
             write_string = ''.join(write_list)
             self.assertEqual(write_string, JSON_FILE_DATA)
+
+
+class TestAsMetadataManager(base.BaseTestCase):
+
+    def setUp(self):
+        super(TestAsMetadataManager, self).setUp()
+        self.mgr = as_metadata_manager.AsMetadataManager(
+            as_metadata_manager.LOG, None)
+
+    @mock.patch('neutron.agent.linux.ip_lib.IpRouteCommand.add_gateway',
+        return_value=[])
+    def test_add_default_route(self, add_gateway_mock):
+        self.mgr.add_default_route('1.2.3.4')
+
+    @mock.patch('neutron.agent.linux.ip_lib.IPWrapper.get_device_by_ip',
+        return_value=None)
+    def test_has_ip(self, get_device_by_ip_mock):
+        result = self.mgr.has_ip('1.2.3.4')
+        self.assertEqual(result, False)
+
+    @mock.patch('opflexagent.as_metadata_manager.AsMetadataManager.has_ip',
+    return_value=False)
+    def test_add_ip(self, has_ip_mock):
+        mock_path = 'neutron.agent.linux.ip_lib.add_ip_address'
+        with mock.patch(mock_path) as add_ip_addr_mock:
+            self.mgr.add_ip('1.2.3.4')
+            add_ip_addr_mock.assert_called_once_with('1.2.3.4/%s' %
+                (as_metadata_manager.SVC_IP_CIDR),
+                as_metadata_manager.SVC_NS_PORT,
+                as_metadata_manager.SVC_NS, 'global', True)
+
+    @mock.patch('opflexagent.as_metadata_manager.AsMetadataManager.has_ip',
+    return_value=True)
+    def test_del_ip(self, has_ip_mock):
+        mock_path = 'neutron.agent.linux.ip_lib.delete_ip_address'
+        with mock.patch(mock_path) as check_out:
+            self.mgr.del_ip('1.2.3.4')
+            check_out.assert_called_once_with('1.2.3.4/%s' %
+                (as_metadata_manager.SVC_IP_CIDR),
+                as_metadata_manager.SVC_NS_PORT,
+                as_metadata_manager.SVC_NS)
+
+    @mock.patch('neutron.agent.linux.ip_lib.IpRouteCommand.add_gateway',
+        return_value=[])
+    @mock.patch('neutron.agent.linux.ip_lib.IPWrapper.ensure_namespace')
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.create_netns')
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.list_netns')
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.create_interface')
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.set_link_attribute')
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.interface_exists',
+        return_value=True)
+    @mock.patch('neutron.privileged.agent.linux.ip_lib.add_ip_address')
+    @mock.patch('neutron.agent.linux.ip_lib.IPWrapper.get_device_by_ip',
+        return_value=None)
+    def test_init_host(self, get_device_by_ip_patch,
+            p_add_ip_addr_route, p_interface_exists_path,
+            p_set_link_attribute_patch, p_create_interface_patch,
+            p_list_netns_patch, p_create_netns_patch,
+            ensure_namespace_patch, add_gateway_patch):
+        self.mgr.init_host()


### PR DESCRIPTION
Start of removing shell calls from as_metadata_manager

These calls require elevated permissions, which we want to avoid.
This commit replaces the shell calls with equivalent calls from ip_lib.

(cherry picked from commit d482725b5c2b6c9f3567acb1269a82c68497101f)
(cherry picked from commit c48766913d126aeae2ebad305b4f5dd5bbacaf67)
(cherry picked from commit 93c5bb4a41d8f0133c52b7d5d48ba49680ce17f1)
(cherry picked from commit c455399537adecbb1cbea82e10cf2f16950cd280)
(cherry picked from commit 4fa3beb22811ab44dbcfbd352fc178bd5de77d0c)
(cherry picked from commit c01cddff84f4ae2284efc8c87045dde2fb3cf0a7)
(cherry picked from commit 74eab659174d3d58959d78447ba4bd903c1cb307)
(cherry picked from commit dab8d072c720605e11ba4b7e5af39572d20efb19)