### PR TITLE
Replaced shell calls in as_metadata_manager

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -17,7 +17,6 @@ import multiprocessing
 import os
 import os.path
 import signal
-import subprocess
 import sys
 import time
 import uuid
@@ -27,15 +26,14 @@ import pyinotify
 from six.moves import queue as Queue
 
 from neutron.agent.common import ip_lib
+from neutron.agent.common import utils as agent_utils
 from neutron.common import config as common_config
 from neutron.common import utils
 from neutron.conf.agent import common as config
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import (  # noqa
     config as ovs_config)
-from neutron_lib.utils import helpers
 from oslo_config import cfg
 from oslo_log import log as logging
-from oslo_utils import encodeutils
 
 from opflexagent._i18n import _
 from opflexagent import config as oscfg  # noqa
@@ -499,7 +497,8 @@ class StateWatcher(FileWatcher):
                 with open(proxyfilename, "w") as f:
                     f.write(proxystr)
                 pidfile = PID_FILE_NAME_FORMAT % asvc["uuid"]
-                self.mgr.sh("rm -f %s" % pidfile)
+                agent_utils.execute(["rm", "-f", pidfile],
+                    run_as_root=True)
             except Exception as e:
                 LOG.warn("EPwatcher: Exception in writing proxy file: %s",
                          str(e))
@@ -543,7 +542,8 @@ class SnatConnTrackHandler(object):
             with open(snatfilename, "w") as f:
                 f.write(conn_track_str)
             pidfile = PID_FILE_NAME_FORMAT % netns
-            self.mgr.sh("rm -f %s" % pidfile)
+            agent_utils.execute(["rm", "-f", pidfile],
+                    run_as_root=True)
             self.mgr.update_supervisor()
         except Exception as e:
             LOG.warn("ConnTrack: Exception in writing snat file: %s",
@@ -614,24 +614,6 @@ class AsMetadataManager(object):
                           "service: %(exc)s",
                           {'name': self.name, 'exc': str(e)})
 
-    def sh(self, cmd, as_root=True):
-        if as_root and self.root_helper:
-            cmd = "%s %s" % (self.root_helper, cmd)
-        LOG.debug("%(name)s: Running command: %(cmd)s",
-                  {'name': self.name, 'cmd': cmd})
-        ret = ''
-        try:
-            sanitized_cmd = encodeutils.to_utf8(cmd)
-            data = subprocess.check_output(
-                sanitized_cmd, stderr=subprocess.STDOUT, shell=True)
-            ret = helpers.safe_decode_utf8(data)
-        except Exception as e:
-            LOG.error("In running command: %(cmd)s: %(exc)s",
-                      {'cmd': cmd, 'exc': str(e)})
-        LOG.debug("%(name)s: Command output: %(ret)s",
-                  {'name': self.name, 'ret': ret})
-        return ret
-
     def write_file(self, name, data):
         LOG.debug("%(name)s: Writing file: name=%(file)s, data=%(data)s",
                   {'name': self.name, 'file': name, 'data': data})
@@ -654,17 +636,22 @@ class AsMetadataManager(object):
 
     def start_supervisor(self):
         self.stop_supervisor()
-        self.sh("supervisord -c %s" % self.md_filename)
+        agent_utils.execute(["supervisord", "-c", self.md_filename],
+            run_as_root=True)
 
     def update_supervisor(self):
-        self.sh("supervisorctl -c %s reread" % self.md_filename)
-        self.sh("supervisorctl -c %s update" % self.md_filename)
+        agent_utils.execute(["supervisorctl", "-c", self.md_filename,
+            "reread"], run_as_root=True)
+        agent_utils.execute(["supervisorctl", "-c", self.md_filename,
+            "update"], run_as_root=True)
 
     def reload_supervisor(self):
-        self.sh("supervisorctl -c %s reload" % self.md_filename)
+        agent_utils.execute(["supervisorctl", "-c", self.md_filename,
+            "reload"], run_as_root=True)
 
     def stop_supervisor(self):
-        self.sh("supervisorctl -c %s shutdown" % self.md_filename)
+        agent_utils.execute(["supervisorctl", "-c", self.md_filename,
+            "shutdown"], run_as_root=True)
         time.sleep(30)
 
     def add_default_route(self, nexthop):
@@ -692,27 +679,32 @@ class AsMetadataManager(object):
         (ipaddr, SVC_IP_CIDR))
 
     def get_asport_mac(self):
-        return self.sh(
-            "ip netns exec %s ip link show %s | "
-            "gawk -e '/link\/ether/ {print $2}'" %
-            (SVC_NS, SVC_NS_PORT))
+        return agent_utils.execute(["ip", "netns", "exec", SVC_NS,
+            "ip", "link", "show", SVC_NS_PORT,
+            "|", "gawk", "-e", "'/link\/ether/ {print $2}'"],
+            check_exit_code=False, log_fail_as_error=True)
 
     def init_host(self):
         # Create required directories
-        self.sh("mkdir -p %s" % PID_DIR)
-        self.sh("rm -f %s/*.pid" % PID_DIR)
-        self.sh("chown %s %s" % (MD_DIR_OWNER, PID_DIR))
-        self.sh("chown %s %s/.." % (MD_DIR_OWNER, PID_DIR))
-        self.sh("mkdir -p %s" % MD_DIR)
-        self.sh("chown %s %s" % (MD_DIR_OWNER, MD_DIR))
+        agent_utils.execute(["mkdir", "-p", PID_DIR],
+            run_as_root=True)
+        agent_utils.execute(["rm", "-f", "%s/*.pid" % PID_DIR],
+            run_as_root=True)
+        agent_utils.execute(["chown", MD_DIR_OWNER, PID_DIR],
+            run_as_root=True)
+        agent_utils.execute(["chown", MD_DIR_OWNER, "%s/.." % PID_DIR],
+            run_as_root=True)
+        agent_utils.execute(["mkdir", "-p", MD_DIR],
+            run_as_root=True)
+        agent_utils.execute(["chown", MD_DIR_OWNER, MD_DIR],
+            run_as_root=True)
 
         # Create namespace, if needed
         ip_lib.IPWrapper().ensure_namespace(SVC_NS)
 
         # Create ports, if needed
-        port = self.sh("ip link show %s 2>&1 | grep qdisc ; true" %
-                       SVC_OVS_PORT)
-        if not port:
+        port_exists = ip_lib.IPDevice(SVC_OVS_PORT, None).exists()
+        if port_exists is False:
             ip_lib.IPWrapper().add_veth(SVC_NS_PORT, SVC_OVS_PORT)
             ip_lib.IPDevice(SVC_OVS_PORT, None).link.set_up()
             ip_lib.IPDevice(SVC_NS_PORT, SVC_NS).link.set_netns(
@@ -720,10 +712,14 @@ class AsMetadataManager(object):
             ip_lib.IPDevice(SVC_NS_PORT, SVC_NS).link.set_up()
             self.add_ip(SVC_IP_DEFAULT)
             self.add_default_route(SVC_NEXTHOP)
-            self.sh("ethtool --offload %s tx off" % SVC_OVS_PORT)
-            self.sh("ip netns exec %s ethtool --offload %s tx off" %
-                    (SVC_NS, SVC_NS_PORT))
-        self.bridge_manager.plug_metadata_port(self.sh, SVC_OVS_PORT)
+            agent_utils.execute(["ethtool", "--offload", SVC_OVS_PORT,
+                "tx", "off"],
+                run_as_root=True)
+            agent_utils.execute(["ip", "netns", "exec", SVC_NS, "ethtool",
+                "--offload", SVC_NS_PORT, "tx", "off"],
+                run_as_root=True)
+        self.bridge_manager.plug_metadata_port(
+            agent_utils.execute, SVC_OVS_PORT)
 
     def init_supervisor(self):
         def conf(*fnames):

--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -105,20 +105,25 @@ class TestAsMetadataManager(base.BaseTestCase):
                 as_metadata_manager.SVC_NS_PORT,
                 as_metadata_manager.SVC_NS)
 
+    def test_get_asport_mac(self):
+        self.mgr.get_asport_mac()
+
     @mock.patch('neutron.privileged.agent.linux.utils.path_exists',
         return_value=True)
     @mock.patch('neutron.privileged.agent.linux.ip_lib.create_interface')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.set_link_attribute')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.interface_exists',
-        return_value=True)
+        side_effect=[False, True])
     @mock.patch('neutron.privileged.agent.linux.ip_lib.add_ip_address')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.add_ip_route')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.get_ip_addresses',
         return_value=[])
-    def test_init_host(self, p_get_ip_addresses_patch, p_add_ip_route_patch,
-            p_add_ip_addr_route, p_interface_exists_path,
-            p_set_link_attribute_patch, p_create_interface_patch,
-            p_path_exists_patch):
+    @mock.patch('neutron.agent.common.utils.execute',
+        return_value=('', ''))
+    def test_init_host(self, execute_patch, p_get_ip_addresses_patch,
+            p_add_ip_route_patch, p_add_ip_addr_route,
+            p_interface_exists_path, p_set_link_attribute_patch,
+            p_create_interface_patch, p_path_exists_patch):
         self.mgr.init_host()
         p_create_interface_patch.assert_called_once_with(
             as_metadata_manager.SVC_NS_PORT, None,

--- a/opflexagent/utils/bridge_managers/ovs_manager.py
+++ b/opflexagent/utils/bridge_managers/ovs_manager.py
@@ -175,8 +175,9 @@ class OvsManager(bridge_manager_base.BridgeManagerBase,
         return removed_eps
 
     def plug_metadata_port(self, dst_shell, port):
-        dst_shell("ovs-vsctl add-port %s %s" % (
-                  cfg.CONF.OPFLEX.fabric_bridge, port))
+        dst_shell(["ovs-vsctl", "add-port",
+            cfg.CONF.OPFLEX.fabric_bridge, port],
+            run_as_root=True)
 
     def delete_port(self, port):
         self.fabric_br.delete_port(port)

--- a/opflexagent/utils/bridge_managers/vpp_manager.py
+++ b/opflexagent/utils/bridge_managers/vpp_manager.py
@@ -160,8 +160,10 @@ class VppManager(bridge_manager_base.BridgeManagerBase,
         return removed_eps
 
     def plug_metadata_port(self, dst_shell, port):
-        dst_shell("vppctl create host-interface name %s" % port)
-        dst_shell("vppctl set interface state %s up" % port)
+        dst_shell(["vppctl", "create", "host-interface", "name", port],
+            run_as_root=True)
+        dst_shell(["vppctl", "set", "interface", "state", port, "up"],
+            run_as_root=True)
 
     # The following methods are called with host-interfaces for SNAT
     # This feature is currently not implemented by VPP


### PR DESCRIPTION
Replaced sh calls with the execute method from neutron's agent utils.

(cherry picked from commit 00f27f377153beacdfc8adfc1ac494aab7fe3194)
(cherry picked from commit e184383f69e6839ef73bbff0ccf3307f49b2bc29)
(cherry picked from commit 0411b0faccfd5493747c3fdb3b502449bbdbcb81)
(cherry picked from commit 7c6e44ae9c5f7c71f3f81dc4804c2af443989005)