### PR TITLE
Fix usage of ip_lib

### DIFF
--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -133,7 +133,7 @@ class TestAsMetadataManager(base.BaseTestCase):
                 None,
                 state='up'),
             mock.call(as_metadata_manager.SVC_NS_PORT,
-                as_metadata_manager.SVC_NS,
+                None,
                 net_ns_fd=as_metadata_manager.SVC_NS),
             mock.call(as_metadata_manager.SVC_NS_PORT,
                 as_metadata_manager.SVC_NS,


### PR DESCRIPTION
Moving a device to a network namespace may require retries. This
patch reuses code from upstream neutron to manage moving an interface
to a network namespace.