### PR TITLE
Fix usage of ip_lib

### DIFF
--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -133,7 +133,7 @@ class TestAsMetadataManager(base.BaseTestCase):
                 None,
                 state='up'),
             mock.call(as_metadata_manager.SVC_NS_PORT,
-                as_metadata_manager.SVC_NS,
+                None,
                 net_ns_fd=as_metadata_manager.SVC_NS),
             mock.call(as_metadata_manager.SVC_NS_PORT,
                 as_metadata_manager.SVC_NS,


### PR DESCRIPTION
Moving a device to a network namespace may require retries. This patch reuses code from upstream neutron to manage moving an interface to a network namespace.

(cherry picked from commit 00bb245a104351124c4fe4b82eefba5179ba2d78) (cherry picked from commit 196b7fbbcd0c55857a12eec6e62a8b0c9e45540b) (cherry picked from commit ee8626b35e595d99143714b26c041088bbadeffd) (cherry picked from commit a934a0d89afa5113559c8496d25ebd48456563c8) (cherry picked from commit 4c1b8e0e18e89bb27884e34bb9ebcf7a0d896e19)