### PR TITLE
Fix usage of ip_lib

### DIFF
--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -115,7 +115,7 @@ class TestAsMetadataManager(base.BaseTestCase):
     @mock.patch('neutron.privileged.agent.linux.ip_lib.create_interface')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.set_link_attribute')
     @mock.patch('neutron.privileged.agent.linux.ip_lib.interface_exists',
-        return_value=True)
+        return_value=False)
     @mock.patch('neutron.privileged.agent.linux.ip_lib.add_ip_address')
     @mock.patch('neutron.agent.linux.ip_lib.IPWrapper.get_device_by_ip',
         return_value=None)
@@ -128,3 +128,11 @@ class TestAsMetadataManager(base.BaseTestCase):
             p_create_netns_patch, ensure_namespace_patch,
             add_gateway_patch):
         self.mgr.init_host()
+        p_set_link_attribute_patch.assert_has_calls([
+            mock.call(as_metadata_manager.SVC_OVS_PORT,
+                None,
+                state='up'),
+            mock.call(as_metadata_manager.SVC_NS_PORT,
+                as_metadata_manager.SVC_NS,
+                state='up')
+        ])


### PR DESCRIPTION
Moving a device to a network namespace may require retries. This patch reuses code from upstream neutron to manage moving an interface to a network namespace.

(cherry picked from commit 00bb245a104351124c4fe4b82eefba5179ba2d78) (cherry picked from commit 196b7fbbcd0c55857a12eec6e62a8b0c9e45540b) (cherry picked from commit ee8626b35e595d99143714b26c041088bbadeffd) (cherry picked from commit a934a0d89afa5113559c8496d25ebd48456563c8) (cherry picked from commit 4c1b8e0e18e89bb27884e34bb9ebcf7a0d896e19) (cherry picked from commit 096617ba49643d82308e7a68ef9ba62796cbf82f) (cherry picked from commit 9008a149c8d50f6332506fde341f40646df9bf3d) (cherry picked from commit 2345a341d6e9974fd7cc764180f87fc33eac67a9)