### PR TITLE
Fix metadata service

### DIFF
--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -106,7 +106,15 @@ class TestAsMetadataManager(base.BaseTestCase):
                 as_metadata_manager.SVC_NS)
 
     def test_get_asport_mac(self):
-        self.mgr.get_asport_mac()
+        iface_str = ('29: of-svc-nsport@if28: '
+                     '<BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc '
+                     'noqueue state UP mode DEFAULT group default qlen 1000\n'
+                     'link/ether 76:b4:fc:32:21:37 '
+                     'brd ff:ff:ff:ff:ff:ff link-netnsid 0\n')
+        with mock.patch('neutron.agent.common.utils.execute',
+                        return_value=iface_str):
+            self.assertEqual(self.mgr.get_asport_mac(),
+                             '76:b4:fc:32:21:37')
 
     @mock.patch('neutron.privileged.agent.linux.utils.execute_process',
         return_value=(None, None, None))


### PR DESCRIPTION
The metadata service wasn't working due to two issues:
*  The supervisord wasn't starting because the "stop" of the metadataservice (done before starting, to ensure there isn't a leftover supervisord) was failing when there wasn't a supervisord process.
*  The script to get the MAC address for the metadata service namespace was failing (the agent utils wasn't allowing the pipe, so it's possible that API only accepts one command).

Both of these issues are addressed in this patch.