### PR TITLE
Remove py37 from gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ matrix:
     - python: 3.7
       env:
         - TOX_ENV=pep8
-    - python: 3.7
-      env:
-        - TOX_ENV=py37
     - python: 3.8
       env:
         - TOX_ENV=py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,pep8
+envlist = py38,pep8
 minversion = 2.3.2
 skipsdist = True
 


### PR DESCRIPTION
The python37 gate no longer works, due to some issue with the version of stevedore that's packaged (3.5.0). This issue isn't seen with previous versions of stevedore, but python37 isn't supported in newer stable openstack releases, so it's dropped from the list of gates.