### PR TITLE
Fix metadata service

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -635,7 +635,12 @@ class AsMetadataManager(object):
         rm_files(MD_DIR, '.conf')
 
     def start_supervisor(self):
-        self.stop_supervisor()
+        try:
+            self.stop_supervisor()
+        except Exception as e:
+            LOG.error("%(name)s: in shuttingdown anycast metadata "
+                      "service: %(exc)s",
+                      {'name': self.name, 'exc': str(e)})
         agent_utils.execute(["supervisord", "-c", self.md_filename],
             run_as_root=True)
 
@@ -679,10 +684,10 @@ class AsMetadataManager(object):
         (ipaddr, SVC_IP_CIDR))
 
     def get_asport_mac(self):
-        return agent_utils.execute(["ip", "netns", "exec", SVC_NS,
-            "ip", "link", "show", SVC_NS_PORT,
-            "|", "gawk", "-e", "'/link\/ether/ {print $2}'"],
-            check_exit_code=False, log_fail_as_error=True)
+        iface_list = agent_utils.execute(["ip", "netns", "exec", SVC_NS,
+            "ip", "link", "show", SVC_NS_PORT], check_exit_code=False,
+            log_fail_as_error=True, run_as_root=True).split()
+        return iface_list[iface_list.index('link/ether') + 1]
 
     def _add_device_to_namespace(self, ip_wrapper, device, namespace):
         namespace_obj = ip_wrapper.ensure_namespace(namespace)

--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -106,7 +106,15 @@ class TestAsMetadataManager(base.BaseTestCase):
                 as_metadata_manager.SVC_NS)
 
     def test_get_asport_mac(self):
-        self.mgr.get_asport_mac()
+        iface_str = ('29: of-svc-nsport@if28: '
+                     '<BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc '
+                     'noqueue state UP mode DEFAULT group default qlen 1000\n'
+                     'link/ether 76:b4:fc:32:21:37 '
+                     'brd ff:ff:ff:ff:ff:ff link-netnsid 0\n')
+        with mock.patch('neutron.agent.common.utils.execute',
+                        return_value=iface_str):
+            self.assertEqual(self.mgr.get_asport_mac(),
+                             '76:b4:fc:32:21:37')
 
     @mock.patch('neutron.privileged.agent.linux.utils.path_exists',
         return_value=True)


### PR DESCRIPTION
The metadata service wasn't working due to two issues:
*  The supervisord wasn't starting because the "stop" of the metadataservice (done before starting, to ensure there isn't a leftover supervisord) was failing when there wasn't a supervisord process.
*  The script to get the MAC address for the metadata service namespace was failing (the agent utils wasn't allowing the pipe, so it's possible that API only accepts one command).

Both of these issues are addressed in this patch.

(cherry picked from commit f5a8048f60cb8bb0c550010651df80c676056280) (cherry picked from commit 60d216b970cd09fd1f587255c72a7fba7340c9ce) (cherry picked from commit b38f2757bd7351b9c7e0683c42cbea2f58464f7d) (cherry picked from commit d3a0077a8a837f224d835c0d9fb639719c49b9a4)