### PR TITLE
Fix call to getting metadata port

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -684,10 +684,14 @@ class AsMetadataManager(object):
         (ipaddr, SVC_IP_CIDR))
 
     def get_asport_mac(self):
-        iface_list = agent_utils.execute(["ip", "netns", "exec", SVC_NS,
+        iface_str = agent_utils.execute(["ip", "netns", "exec", SVC_NS,
             "ip", "link", "show", SVC_NS_PORT], check_exit_code=False,
-            log_fail_as_error=True, run_as_root=True).split()
-        return iface_list[iface_list.index('link/ether') + 1]
+            log_fail_as_error=True, run_as_root=True)
+        if not iface_str:
+            return ''
+        else:
+            iface_list = iface_str.split()
+            return iface_list[iface_list.index('link/ether') + 1]
 
     def _add_device_to_namespace(self, ip_wrapper, device, namespace):
         namespace_obj = ip_wrapper.ensure_namespace(namespace)


### PR DESCRIPTION
The call to get the metadata link info could be None, which would cause an exception with the current implementation. This patch adds a fix to handle the None case.

(cherry picked from commit 20e2f871322fbb1e5fc560860ee808fd8dbee416) (cherry picked from commit b99106b5b9ad3570c7f3d1821230434fa668f6a2) (cherry picked from commit bf9987acf35f558e6468312f9caba62d21df8250) (cherry picked from commit c853b73d66b4e6efd451e86fb91b8fdf6320fe70) (cherry picked from commit fe5db5e0d837413f6ad9ab2fb779389d9c6aafb4)