### PR TITLE
Fix destination ip mapping

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -656,9 +656,11 @@ class AsMetadataManager(object):
 
     def clean_files(self):
         def rm_files(dirname, extension):
+            ignorelist = ['anycast_services.state']
             try:
                 for filename in os.listdir(dirname):
-                    if filename.endswith('.' + extension):
+                    if (filename.endswith('.' + extension) and
+                        filename not in ignorelist):
                         os.remove("%s/%s" % (dirname, filename))
             except Exception:
                 # Yes, one of those few cases, when a pass is OK!


### PR DESCRIPTION
Makes AsMetadataManager not delete the anycast_services file.

(cherry picked from commit 233cefc776cf1eb27c6f8f56b786128a48de45ff)