### PR TITLE
Fix destination ip mapping

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -656,9 +656,11 @@ class AsMetadataManager(object):
 
     def clean_files(self):
         def rm_files(dirname, extension):
+            ignorelist = ['anycast_services.state']
             try:
                 for filename in os.listdir(dirname):
-                    if filename.endswith('.' + extension):
+                    if (filename.endswith('.' + extension) and
+                        filename not in ignorelist):
                         os.remove("%s/%s" % (dirname, filename))
             except Exception:
                 # Yes, one of those few cases, when a pass is OK!


### PR DESCRIPTION
Makes AsMetadataManager not delete the anycast_services file.

(cherry picked from commit 233cefc776cf1eb27c6f8f56b786128a48de45ff)
(cherry picked from commit 7fbb1c9f1cc2d442d03b99ff76d6e410a49887ea)
(cherry picked from commit 36ac51e8cdfe26a4f9b6e73a41796f2e6c61a053)
(cherry picked from commit 21779a806a0ba03b5ac771306f4d054ec9ee4b71)
(cherry picked from commit 7ca50761bd7024377965149a7129db30d25e6826)