### PR TITLE
Fix destination ip mapping

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -656,9 +656,11 @@ class AsMetadataManager(object):
 
     def clean_files(self):
         def rm_files(dirname, extension):
+            ignorelist = ['anycast_services.state']
             try:
                 for filename in os.listdir(dirname):
-                    if filename.endswith('.' + extension):
+                    if (filename.endswith('.' + extension) and
+                        filename not in ignorelist):
                         os.remove("%s/%s" % (dirname, filename))
             except Exception:
                 # Yes, one of those few cases, when a pass is OK!

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 hacking>=1.1.0,<1.2.0 # Apache-2.0
 
--e git+https://opendev.org/openstack/neutron.git@stable/rocky#egg=neutron
+-e git+https://github.com/openstack/neutron.git@rocky-eol#egg=neutron
 
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3


### PR DESCRIPTION
Makes AsMetadataManager not delete the anycast_services file.

(cherry picked from commit 233cefc776cf1eb27c6f8f56b786128a48de45ff)
(cherry picked from commit 7fbb1c9f1cc2d442d03b99ff76d6e410a49887ea)
(cherry picked from commit 36ac51e8cdfe26a4f9b6e73a41796f2e6c61a053)
(cherry picked from commit 21779a806a0ba03b5ac771306f4d054ec9ee4b71)
(cherry picked from commit 7ca50761bd7024377965149a7129db30d25e6826)
(cherry picked from commit de6da37aa294b748850476e03ff6c9fe4ba6fc6e)
(cherry picked from commit 45218c9da0e1edd0a0eb46a4070650d16a1637de)
(cherry picked from commit 14d910372b284cbec700d57539e4d4fd76a21006)
(cherry picked from commit 27a2182b3054babedfa60fff3a130c1474ede376)