### PR TITLE
Fixed has_ip check in AsMetadataManager

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -690,7 +690,7 @@ class AsMetadataManager(object):
     def has_ip(self, ipaddr):
         outp = self.sh("ip netns exec %s ip addr show dev %s" %
                 (SVC_NS, SVC_NS_PORT))
-        return 'inet %s' % (ipaddr, ) in outp
+        return 'net %s/' % (ipaddr, ) in outp
 
     def add_ip(self, ipaddr):
         if self.has_ip(ipaddr):


### PR DESCRIPTION
Fixed the text match case so that it checks for the proper ip.

(cherry picked from commit b314de32b4edcfe98aa29aefe9974df71ead8122)