### PR TITLE
Fixed has_ip check in AsMetadataManager

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -692,7 +692,7 @@ class AsMetadataManager(object):
     def has_ip(self, ipaddr):
         outp = self.sh("ip netns exec %s ip addr show dev %s" %
                 (SVC_NS, SVC_NS_PORT))
-        return 'inet %s' % (ipaddr, ) in outp
+        return 'net %s/' % (ipaddr, ) in outp
 
     def add_ip(self, ipaddr):
         if self.has_ip(ipaddr):


### PR DESCRIPTION
Fixed the text match case so that it checks for the proper ip.

(cherry picked from commit b314de32b4edcfe98aa29aefe9974df71ead8122)
(cherry picked from commit 742bcb0ce8ce1da977fcae4f1054ddf21bcb0001)
(cherry picked from commit d69d40434f23fd65d4aff0e3807f9b3bad743b6c)
(cherry picked from commit b61d7a59445f6f66d5cbd8d45ee0aa871d4b4d64)
(cherry picked from commit 73bd3fd2a36b3f02d09b03afb985333a4e62a7bd)
(cherry picked from commit 8c45602d6bd8f51405f9112c338767a959572e17)
(cherry picked from commit 770d454edbb7e4eafd3befcfce9a67b9cc55f0c1)