### PR TITLE
Fix mapped IP reuse

### DIFF
--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -798,7 +798,17 @@ class TestEndpointFileManager(base.OpflexTestBase):
 
     def test_existing_snat_endpoints(self):
         # Init directory
-        self.manager._write_file('uuid1_AA', {}, self.manager.epg_mapping_file)
+        self.manager._write_file('uuid1_AA', {
+            "access-interface": "tapb79d3176-8d",
+            "mac": "fa:16:3e:47:31:bc",
+            "ip-address-mapping": [{
+                "uuid": "374c00fc-3589-4433-89d1-d9c74493b4d6",
+                "mapped-ip": "40.40.40.246",
+                "floating-ip": "169.254.0.1",
+                "policy-space-name": "common",
+                "endpoint-group-name": "ostack-bm-2_OpenStack|EXT-fab2041_2"
+            }]
+        }, self.manager.epg_mapping_file)
         self.manager._write_file('EXT-1', {}, self.manager.epg_mapping_file)
         self.manager._write_file('EXT-2', {}, self.manager.epg_mapping_file)
         self.manager._write_file('EXT-3', {}, self.manager.epg_mapping_file)
@@ -812,6 +822,8 @@ class TestEndpointFileManager(base.OpflexTestBase):
             manager = self._initialize_agent()
             self.assertEqual(set(['uuid1']),
                              manager.get_registered_endpoints())
+            self.assertIsNone(manager.old_snat_fips.get(
+                                 'fa:16:3e:47:31:bc40.40.40.246'))
             self.assertEqual(set(['EXT-1.ep', 'EXT-3.ep']),
                              manager.get_stale_endpoints())
             manager.snat_iptables.cleanup_snat_all.assert_called_once_with(

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -270,6 +270,12 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                                     access_int})
                                 for ip_map in ep_opts.get(
                                         'ip-address-mapping', []):
+                                    # Don't save non-SNAT mappings
+                                    if ('next-hop-if' not in list(
+                                            ip_map.keys()) or not
+                                            ip_map['floating-ip'].startswith(
+                                                '169.254')):
+                                        continue
                                     snat_key = (ep_opts['mac'] +
                                                 ip_map['mapped-ip'])
                                     fip = ip_map['floating-ip']


### PR DESCRIPTION
Commit 099812fb86857650469714878e64f6c6400537da added support for maintaining SNAT IP mappings across restarts, but introduced a regression for non-SNAT mapped IPs. This patch limits reuse of mapped IPs to SNAT IPs.

(cherry picked from commit 1ba68074b508faedeaf4992ef42e1e9114b8dfe7) (cherry picked from commit cb8e8b91a783db0aaa255b2eb06dfc7398cf4c52) (cherry picked from commit 5a1a8fbcba3eb79901945a2b359eb08bca0e9dbc) (cherry picked from commit 6a55d3f77f98f63952f598662e4da422bb6bb3cb) (cherry picked from commit f7ff4c3ee3c0674e0244750d11d31dcb8d8ad76b) (cherry picked from commit de5a02a792a38a7407da055ca9379610e35171f4) (cherry picked from commit 8734eb50cfb13067e06068c82ceaf6403eacf0b8) (cherry picked from commit 81bb4bf375ad862c5c3457a14a22b6aae98a0a3e) (cherry picked from commit ae25a41a6d770e613ff5486f8904f880f27a15ab) (cherry picked from commit cd3f30eaf30c94055205bdfb7bd64083e8a50d1a) (cherry picked from commit f8bc65d8f6b714260ab1ea5abbbd5d540a6576b2)