### PR TITLE
Add netstat to rootwrap filters

### DIFF
--- a/etc/cisco-apic.filters
+++ b/etc/cisco-apic.filters
@@ -18,3 +18,6 @@ ovsdb-client: CommandFilter, ovsdb-client, root
 
 # nft filters
 nft: CommandFilter, iptables-nft, root
+
+# netstat filters
+netstat: CommandFilter, netstat, root


### PR DESCRIPTION
Container privileges have removed the abiltiy of the neutron user to run netstat commands. This patch adds netstat to the list of rootwrap filters (used by the opflex-agent's supervisord to monitor connections with peers).

(cherry picked from commit be5ff167d9e9a44a376939148bf557530d74288b) (cherry picked from commit e4eccf711d15e6a2f3bb4cc56da70b4af3de188e) (cherry picked from commit d9b03996f019ace976923d9424f7a33b55898bdb) (cherry picked from commit c5bde04bbcc4561e8dc7fcaf5f3d0a40ef05cfb5) (cherry picked from commit 6aec1e4c76deb75b5902415cdc88a1e5248808d3) (cherry picked from commit 28b8fb5196a15feb49d98105f9913ab9afa9fea9) (cherry picked from commit 1bd50730dff157d1dcc1058c4fd6377362d6c02a) (cherry picked from commit 995316a4e877792b5a7e29d1d374a3309e5cdefc)