### PR TITLE
Pin setuptools<81 to fix pep8 failure

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
 
+setuptools<81
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,11 +4,10 @@
 hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
-# remove support of setuptools
-# setuptools<81
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
-flake8-import-order==0.12 # LGPLv3
+flake8-import-order~=0.19.2
+# flake8-import-order==0.12 # LGPLv3
 testtools>=2.2.0 # MIT
 testresources>=2.0.0 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,8 @@
 hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
-
-setuptools<81
+# remove support of setuptools
+# setuptools<81
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands = {posargs}
 # N530: Direct neutron imports not allowed
 # N535: Usage of Python eventlet module not allowed
 
-ignore = E126,E128,E129,E741,H401,H404,H405,W504,W605,N521,N529,N530,N534,N535
+ignore = E126,E128,E129,E741,H401,H404,H405,I202,W504,W605,N521,N529,N530,N534,N535
 # H106: Don’t put vim configuration in source files
 # H203: Use assertIs(Not)None to check for None
 # H204: Use assert(Not)Equal to check for equality


### PR DESCRIPTION
flake8-import-order requires pkg_resources, which was removed from recent setuptools releases. Pin to <81 to keep CI green.