### PR TITLE
Pin setuptools<81 to fix pep8 failure

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
 
+setuptools<81
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,8 @@
 hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
-
-setuptools<81
+# remove
+# setuptools<81
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3


### PR DESCRIPTION
flake8-import-order requires pkg_resources, which was removed from recent setuptools releases. Pin to <81 to keep CI green.