### PR TITLE
Pin setuptools<82 to fix  gate jobs failure

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ hacking>=3.0.1,<3.1.0 # Apache-2.0
 
 neutron
 
+setuptools<82
 contextlib2>=0.5.4
 coverage!=4.4,>=4.0 # Apache-2.0
 flake8-import-order==0.12 # LGPLv3


### PR DESCRIPTION
pkg_resources removed from recent setuptools releases. Pin to <82 to keep CI green.