### PR TITLE
Fix namespace proxy

### DIFF
--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -209,6 +209,7 @@ def main():
                           "its initialization")),
     ]
 
+    config.register_common_config_options()
     cfg.CONF.register_cli_opts(opts)
     # Don't get the default configuration file
     cfg.CONF(project='neutron', default_config_files=[])


### PR DESCRIPTION
The namespace proxy needs to register the correct upstream options.

(cherry picked from commit ce086d7ae4884c18fe8968156c55870096a93b47) (cherry picked from commit d1460589fe1f680a3ca8356ebc8bab0b55d71d17)