### PR TITLE
Fix namespace proxy

### DIFF
--- a/opflexagent/namespace_proxy.py
+++ b/opflexagent/namespace_proxy.py
@@ -209,6 +209,7 @@ def main():
                           "its initialization")),
     ]
 
+    config.register_common_config_options()
     cfg.CONF.register_cli_opts(opts)
     # Don't get the default configuration file
     cfg.CONF(project='neutron', default_config_files=[])


### PR DESCRIPTION
The namespace proxy needs to register the correct upstream options.

(cherry picked from commit ce086d7ae4884c18fe8968156c55870096a93b47) (cherry picked from commit d1460589fe1f680a3ca8356ebc8bab0b55d71d17) (cherry picked from commit 4ec7eeea66e42856df77171f9757e9b7f675fab3) (cherry picked from commit 749e890de1c2c1cf8ad0444b9b86dfb9aba277ad) (cherry picked from commit d391ec9de0e3c174a4b6370448fcf762a5ee042e)