### PR TITLE
Add support for Distributed SNAT

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -24,6 +24,10 @@ gbp_opts = [
                default='/var/lib/opflex-agent-ovs/services/',
                help=_("Directory where the anycast svc mappings will be "
                       "stored.")),
+    cfg.StrOpt('snats_mapping_dir',
+               default='/var/lib/opflex-agent-ovs/snats/',
+               help=_("Directory where distributed SNAT mapping files will "
+                      "be stored.")),
     cfg.StrOpt('opflex_agent_dir',
                default='/var/lib/neutron/opflex_agent',
                help=_("Directory where the opflex agent state will be "

--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -1,0 +1,187 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import hashlib
+import os
+import uuid
+
+
+SNAT_FILE_EXTENSION = 'snat'
+SNAT_FILE_FORMAT = "%s." + SNAT_FILE_EXTENSION
+SERVICE_FILE_EXTENSION = 'service'
+SERVICE_FILE_FORMAT = "%s." + SERVICE_FILE_EXTENSION
+
+
+class DistributedSnatManager(object):
+    """Distributed SNAT state manager for endpoint-based rendering.
+
+    This class intentionally keeps logic minimal and reuses the existing
+    endpoint manager file writer/delete helpers for all filesystem updates.
+    """
+
+    def __init__(self, snats_dir, service_dir, write_fn, delete_fn):
+        self.snat_mapping_file = os.path.join(snats_dir, SNAT_FILE_FORMAT)
+        self.service_mapping_file = os.path.join(service_dir,
+                                                 SERVICE_FILE_FORMAT)
+        self._write_file = write_fn
+        self._delete_file = delete_fn
+
+        # snat_uuid -> set(endpoint_uuid)
+        self._snat_to_endpoints = {}
+        # endpoint_uuid -> set(snat_uuid)
+        self._endpoint_to_snats = {}
+        # snat_uuid -> {snat_ip,start,end}
+        self._snat_to_ip_range = {}
+
+    def sync_endpoint(self, endpoint_uuid, dist_snat_entries, ep_mapping):
+        old_snats = self._endpoint_to_snats.get(endpoint_uuid, set())
+        new_snats = set()
+
+        for entry in (dist_snat_entries or []):
+            snat_uuid = entry.get('uuid')
+            if not snat_uuid:
+                continue
+
+            new_snats.add(snat_uuid)
+            self._snat_to_endpoints.setdefault(snat_uuid, set()).add(
+                endpoint_uuid)
+            self._snat_to_ip_range[snat_uuid] = {
+                'snat_ip': entry.get('snat_ip'),
+                'start': entry.get('start'),
+                'end': entry.get('end')}
+
+            if entry.get('snat_file'):
+                self._write_file(snat_uuid, entry['snat_file'],
+                                 self.snat_mapping_file)
+            if entry.get('service_file'):
+                self._write_file(snat_uuid, entry['service_file'],
+                                 self.service_mapping_file)
+
+        for snat_uuid in (old_snats - new_snats):
+            self._discard_snat_for_endpoint(endpoint_uuid, snat_uuid)
+
+        if new_snats:
+            ep_mapping['snat-uuids'] = sorted(new_snats)
+            self._endpoint_to_snats[endpoint_uuid] = new_snats
+        else:
+            ep_mapping.pop('snat-uuids', None)
+            self._endpoint_to_snats.pop(endpoint_uuid, None)
+
+    def cleanup_port(self, port_id):
+        for ep_uuid in [x for x in list(self._endpoint_to_snats)
+                        if x.startswith(port_id + '|')]:
+            for snat_uuid in list(self._endpoint_to_snats.get(ep_uuid, set())):
+                self._discard_snat_for_endpoint(ep_uuid, snat_uuid)
+            self._endpoint_to_snats.pop(ep_uuid, None)
+
+    def get_dist_snat_mappings(self):
+        result = {}
+        for info in list(self._snat_to_ip_range.values()):
+            if info.get('snat_ip') and info.get('start') is not None:
+                result[info['snat_ip']] = {
+                    'start': info['start'],
+                    'end': info['end']}
+        return result
+
+    def _discard_snat_for_endpoint(self, endpoint_uuid, snat_uuid):
+        eps = self._snat_to_endpoints.get(snat_uuid, set())
+        eps.discard(endpoint_uuid)
+        if eps:
+            return
+
+        self._snat_to_endpoints.pop(snat_uuid, None)
+        self._snat_to_ip_range.pop(snat_uuid, None)
+        self._delete_file(snat_uuid, self.snat_mapping_file)
+        self._delete_file(snat_uuid, self.service_mapping_file)
+
+    def _stable_dist_snat_uuid(self, hsi):
+        seed = '%s|%s|%s' % (
+            hsi.get('host_snat_ip', ''),
+            hsi.get('external_segment_name', ''),
+            hsi.get('service_ip', ''))
+        digest = hashlib.md5(seed.encode('utf-8')).hexdigest()
+        return str(uuid.UUID(digest))
+
+    def _safe_int(self, value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def build_dist_snat_entries(self, mapping, mapping_dict):
+        dist_entries = []
+        host_snat_ips = mapping.get('host_snat_ips', [])
+        interface_name = mapping_dict.get('interface-name')
+        interface_vlan = mapping_dict.get('access-interface-vlan')
+        service_domain = mapping.get('vrf_tenant', 'common')
+
+        for hsi in host_snat_ips:
+            start = self._safe_int(hsi.get('start_port'))
+            end = self._safe_int(hsi.get('end_port'))
+            if start is None or end is None:
+                continue
+
+            snat_uuid = self._stable_dist_snat_uuid(hsi)
+            service_mac = hsi.get('service_mac') or hsi.get('host_snat_mac')
+            service_nodes = []
+            for node in hsi.get('service_nodes', []):
+                node_start = self._safe_int(node.get('start_port'))
+                node_end = self._safe_int(node.get('end_port'))
+                if node_start is None or node_end is None:
+                    continue
+                service_nodes.append({
+                    'mac': node.get('mac'),
+                    'port-range': [{'start': node_start, 'end': node_end}]
+                })
+
+            snat_file = {
+                'uuid': snat_uuid,
+                'interface-name': interface_name,
+                'snat-ip': hsi.get('host_snat_ip'),
+                'interface-mac': service_mac,
+                'local': True,
+                'dest': [hsi.get('dest_prefix', '0.0.0.0/0')],
+                'port-range': [{'start': start, 'end': end}],
+                'remote': service_nodes,
+            }
+            if interface_vlan is not None:
+                snat_file['interface-vlan'] = interface_vlan
+
+            service_file = {
+                'uuid': snat_uuid,
+                'domain-policy-space': service_domain,
+                'domain-name': (
+                    hsi.get('service_vrf') or
+                    mapping.get('vrf_name')
+                ),
+                'service-mode': 'loadbalancer',
+                'service-mac': service_mac,
+                'interface-name': interface_name,
+                'interface-ip': hsi.get('service_ip'),
+                'service-mapping': [{
+                    'next-hop-ips': None,
+                    'terminating-next-hop-ips': None,
+                    'conntrack-enabled': True,
+                }]
+            }
+            if interface_vlan is not None:
+                service_file['interface-vlan'] = interface_vlan
+
+            dist_entries.append({
+                'uuid': snat_uuid,
+                'snat_ip': hsi.get('host_snat_ip'),
+                'start': start,
+                'end': end,
+                'snat_file': snat_file,
+                'service_file': service_file,
+            })
+        return dist_entries

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -150,6 +150,12 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         # How many devices are likely used by a VM
         self.agent_state.get('configurations')['devices'] = (
             self.bridge_manager.int_br_device_count)
+        ep_mgr = getattr(self, 'ep_manager', None)
+        if ep_mgr and hasattr(ep_mgr, 'get_dist_snat_mappings'):
+            self.agent_state.get('configurations')['dist_snat_mappings'] = (
+                ep_mgr.get_dist_snat_mappings())
+        else:
+            self.agent_state.get('configurations')['dist_snat_mappings'] = {}
 
         try:
             self.state_rpc.report_state(self.context,
@@ -625,6 +631,8 @@ def _parse_files(conf_files):
 def create_agent_config_map(conf):
     agent_config = {}
     agent_config['epg_mapping_dir'] = conf.OPFLEX.epg_mapping_dir
+    agent_config['as_mapping_dir'] = conf.OPFLEX.as_mapping_dir
+    agent_config['snats_mapping_dir'] = conf.OPFLEX.snats_mapping_dir
     agent_config['opflex_networks'] = conf.OPFLEX.opflex_networks
     agent_config['vlan_networks'] = conf.OPFLEX.vlan_networks
     agent_config['endpoint_request_timeout'] = (

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Cisco Systems
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import os
+import shutil
+
+from oslo_utils import uuidutils
+
+from opflexagent import distributed_snat_manager
+from opflexagent.test import base
+
+
+class TestDistributedSnatManager(base.OpflexTestBase):
+
+    def setUp(self):
+        super(TestDistributedSnatManager, self).setUp()
+        self.tmp_root = '.%s_dist_snat/' % uuidutils.generate_uuid()
+        self.addCleanup(self._cleanup)
+
+        def _write(uuid, mapping_dict, file_format):
+            filename = file_format % uuid
+            directory = os.path.dirname(filename)
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+            with open(filename, 'w') as f:
+                json.dump(mapping_dict, f)
+            return filename
+
+        def _delete(uuid, file_format):
+            try:
+                os.remove(file_format % uuid)
+            except OSError:
+                pass
+
+        self.mgr = distributed_snat_manager.DistributedSnatManager(
+            os.path.join(self.tmp_root, 'snats'),
+            os.path.join(self.tmp_root, 'service'),
+            _write,
+            _delete)
+
+    def _cleanup(self):
+        try:
+            shutil.rmtree(self.tmp_root)
+        except OSError:
+            pass
+
+    def test_sync_endpoint_writes_files_and_ep_uuid_refs(self):
+        ep_mapping = {}
+        dist_entry = {
+            'uuid': '00000000-0000-0000-0000-ffff980a0114',
+            'snat_ip': '66.66.66.7',
+            'start': 100,
+            'end': 199,
+            'snat_file': {
+                'uuid': '00000000-0000-0000-0000-ffff980a0114',
+                'snat-ip': '66.66.66.7',
+                'port-range': [{'start': 100, 'end': 199}]},
+            'service_file': {
+                'uuid': '00000000-0000-0000-0000-ffff980a0114',
+                'interface-ip': '16.5.168.7'}
+        }
+
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff',
+                               [dist_entry],
+                               ep_mapping)
+
+        self.assertEqual(['00000000-0000-0000-0000-ffff980a0114'],
+                         ep_mapping.get('snat-uuids'))
+        self.assertEqual(
+            {'66.66.66.7': {'start': 100, 'end': 199}},
+            self.mgr.get_dist_snat_mappings())
+
+        snat_file = os.path.join(self.tmp_root, 'snats',
+                                 '00000000-0000-0000-0000-ffff980a0114.snat')
+        service_file = os.path.join(
+            self.tmp_root, 'service',
+            '00000000-0000-0000-0000-ffff980a0114.service')
+        self.assertTrue(os.path.exists(snat_file))
+        self.assertTrue(os.path.exists(service_file))
+
+    def test_cleanup_port_deletes_files_when_last_endpoint_removed(self):
+        dist_entry = {
+            'uuid': '00000000-0000-0000-0000-ffff980a0114',
+            'snat_ip': '66.66.66.7',
+            'start': 100,
+            'end': 199,
+            'snat_file': {'uuid': '00000000-0000-0000-0000-ffff980a0114'},
+            'service_file': {'uuid': '00000000-0000-0000-0000-ffff980a0114'}
+        }
+
+        self.mgr.sync_endpoint('port-id|aa', [dist_entry], {})
+        self.mgr.sync_endpoint('port-id-2|bb', [dist_entry], {})
+
+        self.mgr.cleanup_port('port-id')
+        # still referenced by port-id-2
+        self.assertNotEqual({}, self.mgr.get_dist_snat_mappings())
+
+        self.mgr.cleanup_port('port-id-2')
+        self.assertEqual({}, self.mgr.get_dist_snat_mappings())
+
+    def test_build_dist_snat_entries_from_host_snat_ips(self):
+        mapping = {
+            'host_snat_ips': [{
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'service_mac': 'aa:bb:cc:00:22:66',
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+                'service_vrf': 'vrf-svc',
+                'dest_prefix': '0.0.0.0/0',
+                'service_nodes': [{
+                    'mac': 'dd:ee:ff:00:11:22',
+                    'start_port': 20000,
+                    'end_port': 20999,
+                }],
+            }],
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
+        mapping_dict = {'interface-name': 'qpi'}
+
+        entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
+
+        self.assertEqual(1, len(entries))
+        entry = entries[0]
+        self.assertEqual('200.0.0.50', entry['snat_ip'])
+        self.assertEqual(10000, entry['start'])
+        self.assertEqual(10999, entry['end'])
+        self.assertEqual('qpi', entry['snat_file']['interface-name'])
+        self.assertEqual('200.0.0.50', entry['snat_file']['snat-ip'])
+        self.assertEqual('aa:bb:cc:00:22:66',
+                         entry['snat_file']['interface-mac'])
+        self.assertEqual([{'start': 10000, 'end': 10999}],
+                         entry['snat_file']['port-range'])
+        self.assertEqual('apic_tenant',
+                         entry['service_file']['domain-policy-space'])
+        self.assertEqual('vrf-svc', entry['service_file']['domain-name'])
+        self.assertEqual('10.99.0.1', entry['service_file']['interface-ip'])

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -55,6 +55,10 @@ class TestEndpointFileManager(base.OpflexTestBase):
 
     def _initialize_agent(self):
         cfg.CONF.set_override('epg_mapping_dir', self.ep_dir, 'OPFLEX')
+        cfg.CONF.set_override('snats_mapping_dir',
+                              self.ep_dir + 'snats/', 'OPFLEX')
+        cfg.CONF.set_override('as_mapping_dir',
+                              self.ep_dir + 'services/', 'OPFLEX')
         kwargs = gbp_agent.create_agent_config_map(cfg.CONF)
         agent = endpoint_file_manager.EndpointFileManager().initialize(
             'h1', mock.Mock(), kwargs)
@@ -72,6 +76,11 @@ class TestEndpointFileManager(base.OpflexTestBase):
         agent.snat_iptables = mock.Mock()
         agent.snat_iptables.setup_snat_for_es = mock.Mock(
             return_value=tuple([None, None]))
+        agent.dist_snat_manager = mock.Mock()
+        agent.dist_snat_manager.build_dist_snat_entries = mock.Mock(
+            return_value=[])
+        agent.dist_snat_manager.get_dist_snat_mappings = mock.Mock(
+            return_value={})
 
     def _port(self):
         port = mock.Mock()
@@ -1277,3 +1286,66 @@ class TestEndpointFileManager(base.OpflexTestBase):
                           'nat_epg_tenant': 'nat-epg-tenant'}])
         self.manager.declare_endpoint(port_1, mapping)
         self.manager.undeclare_endpoint(port_1.vif_id)
+
+    def test_dist_snat_host_snat_ips_delegates_to_manager(self):
+        """Endpoint manager should delegate dist-SNAT entry construction to
+        DistributedSnatManager and pass those entries through to sync.
+        """
+        mapping = self._get_gbp_details(
+            floating_ip=[],
+            host_snat_ips=[{
+                'external_segment_name': 'EXT-1',
+                'host_snat_ip': '200.0.0.50',
+                'gateway_ip': '200.0.0.1',
+                'prefixlen': 8,
+                'start_port': 10000,
+                'end_port': 10999,
+            }])
+
+        dist_entries = [{
+            'uuid': '00000000-0000-0000-0000-ffff980a0114',
+            'snat_ip': '200.0.0.50',
+            'start': 10000,
+            'end': 10999,
+            'snat_file': {'uuid': '00000000-0000-0000-0000-ffff980a0114'},
+            'service_file': {'uuid': '00000000-0000-0000-0000-ffff980a0114'},
+        }]
+        self.manager.dist_snat_manager.build_dist_snat_entries.return_value = (
+            dist_entries)
+
+        def _sync_side_effect(endpoint_uuid, entries, ep_mapping):
+            ep_mapping['snat-uuids'] = sorted(
+                [x['uuid'] for x in entries if x.get('uuid')])
+
+        self.manager.dist_snat_manager.sync_endpoint.side_effect = (
+            _sync_side_effect)
+
+        port = self._port()
+        self.manager.declare_endpoint(port, mapping)
+
+        self.assertTrue(
+            self.manager.dist_snat_manager.build_dist_snat_entries.called)
+        build_call = (
+            self.manager.dist_snat_manager.build_dist_snat_entries.call_args)
+        # Endpoint manager may enrich mapping before delegation; verify
+        # that core distributed-SNAT inputs are preserved.
+        delegated_mapping = build_call[0][0]
+        self.assertEqual(mapping['host_snat_ips'],
+                         delegated_mapping.get('host_snat_ips'))
+        self.assertEqual(mapping['vrf_tenant'],
+                         delegated_mapping.get('vrf_tenant'))
+        self.assertEqual('qpi', build_call[0][1].get('interface-name'))
+
+        self.manager.dist_snat_manager.sync_endpoint.assert_called_once()
+        sync_call = self.manager.dist_snat_manager.sync_endpoint.call_args
+        self.assertEqual(dist_entries, sync_call[0][1])
+
+        # Distributed host_snat_ips must not be consumed by legacy SNAT path.
+        self.assertFalse(self.manager.snat_iptables.setup_snat_for_es.called)
+
+        ep_name = port.vif_id + '_' + mapping['mac_address']
+        ep_write = [x for x in self.manager._write_endpoint_file.
+                    call_args_list if x[0][0] == ep_name]
+        self.assertTrue(ep_write)
+        self.assertEqual(['00000000-0000-0000-0000-ffff980a0114'],
+                         ep_write[0][0][1].get('snat-uuids'))

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -82,6 +82,10 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
 
     def _initialize_agent(self):
         cfg.CONF.set_override('epg_mapping_dir', self.ep_dir, 'OPFLEX')
+        cfg.CONF.set_override('snats_mapping_dir',
+                              self.ep_dir + 'snats/', 'OPFLEX')
+        cfg.CONF.set_override('as_mapping_dir',
+                              self.ep_dir + 'services/', 'OPFLEX')
         kwargs = gbp_agent.create_agent_config_map(cfg.CONF)
 
         class MockFixedIntervalLoopingCall(object):
@@ -192,51 +196,17 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
         self.agent.subnet_update(mock.Mock(), fake_sub)
         self.assertEqual(set(['tenant-id']), self.agent.updated_vrf)
 
-    def test_binding_activate(self):
-        self.agent.binding_activate('context', port_id='id', host='host1')
-        self.assertIn('id', self.agent.activated_bindings)
+    def test_report_state_includes_dist_snat_mappings(self):
+        self.agent.state_rpc = mock.Mock()
+        self.agent.ep_manager.get_dist_snat_mappings = mock.Mock(
+            return_value={'66.66.66.7': {'start': 100, 'end': 199}})
 
-    def test_binding_activate_not_for_host(self):
-        self.agent.binding_activate('context', port_id='id', host='other-host')
-        self.assertEqual(set(), self.agent.activated_bindings)
+        self.agent._report_state()
 
-    def test_process_activated_bindings(self):
-        port_info = {}
-        port_info['added'] = set(['added_port_id'])
-        port_info['current'] = set(['activated_port_id'])
-        self.agent.process_activated_bindings(port_info,
-                                              set(['activated_port_id']))
-        self.assertIn('added_port_id', port_info['added'])
-        self.assertIn('activated_port_id', port_info['added'])
-
-    def test_process_activated_bindings_activated_port_not_present(self):
-        port_info = {}
-        port_info['added'] = set(['added_port_id'])
-        port_info['current'] = set()
-        self.agent.process_activated_bindings(port_info,
-                                              set(['activated_port_id']))
-        self.assertIn('added_port_id', port_info['added'])
-        self.assertNotIn('activated_port_id', port_info['added'])
-
-    def test_binding_deactivate_not_for_host(self):
-        self.agent.binding_deactivate('unused_context', port_id='id',
-                                      host='other_host')
-        self.assertEqual(set(), self.agent.deactivated_bindings)
-
-    def test_binding_deactivate(self):
-        self.agent.binding_deactivate('unused_context', port_id='id',
-                                      host='host1')
-        self.assertEqual(set(['id']), self.agent.deactivated_bindings)
-        self.agent.process_deactivated_bindings(port_info={})
-        self.assertEqual(set(), self.agent.deactivated_bindings)
-
-    def test_binding_deactivate_removed_port(self):
-        self.agent.binding_deactivate('unused_context', port_id='id',
-                                      host='host1')
-        self.assertEqual(set(['id']), self.agent.deactivated_bindings)
-        self.agent.process_deactivated_bindings(
-            port_info={'removed': {'id', }})
-        self.assertEqual(set(), self.agent.deactivated_bindings)
+        self.assertEqual(
+            {'66.66.66.7': {'start': 100, 'end': 199}},
+            self.agent.agent_state['configurations']['dist_snat_mappings'])
+        self.assertTrue(self.agent.state_rpc.report_state.called)
 
     def test_subnet_has_updates(self):
         fake_sub = {'tenant_id': 'tenant-id', 'id': 'someid'}

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -24,6 +24,7 @@ from oslo_utils import uuidutils
 
 from opflexagent import as_metadata_manager
 from opflexagent import constants as ofcst
+from opflexagent import distributed_snat_manager
 from opflexagent import snat_iptables_manager
 from opflexagent.utils.ep_managers import endpoint_manager_base
 
@@ -97,6 +98,12 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
         self.snat_iptables = snat_iptables_manager.SnatIptablesManager(
             bridge_manager)
+        self.dist_snat_manager = (
+                distributed_snat_manager.DistributedSnatManager(
+                    config['snats_mapping_dir'],
+                    config['as_mapping_dir'],
+                    self._write_file,
+                    self._delete_file))
         self._registered_endpoints = set()
         self._stale_endpoints = set()
         self.vif_int_dict = {}
@@ -221,6 +228,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
     def undeclare_endpoint(self, port_id):
         LOG.info("Endpoint undeclare requested for port %s", port_id)
         self._mapping_cleanup(port_id)
+        self.dist_snat_manager.cleanup_port(port_id)
         self._registered_endpoints.discard(port_id)
         self._stale_endpoints.discard(port_id)
         self.vif_int_dict.pop(port_id, None)
@@ -233,6 +241,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
     def get_access_int_for_vif(self, vif):
         return self.vif_int_dict.get(vif)
+
+    def get_dist_snat_mappings(self):
+        return self.dist_snat_manager.get_dist_snat_mappings()
 
     # Private Methods
 
@@ -474,7 +485,7 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
             mapping_dict.setdefault('attributes', {}).update({
                 x[0].strip(): x[2].strip() for x in lbls})
 
-        self._handle_host_snat_ip(mapping.get('host_snat_ips', []))
+        self._handle_host_snat_ip(mapping, mapping_dict)
         self._fill_ip_mapping_info(port.vif_id, mac, mapping,
                                    sorted(ips + ips_aap + ips_ext),
                                    mapping_dict)
@@ -591,8 +602,24 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
 
         return vlan_ranges
 
-    def _handle_host_snat_ip(self, host_snat_ips):
+    def _handle_host_snat_ip(self, mapping, mapping_dict):
+        host_snat_ips = mapping.get('host_snat_ips', [])
+
+        # Distributed SNAT and legacy host-SNAT share host_snat_ips input,
+        # but they must not both program state for the same entry.
+        dist_snat_entries = self.dist_snat_manager.build_dist_snat_entries(
+            mapping, mapping_dict)
+        self.dist_snat_manager.sync_endpoint(mapping_dict['uuid'],
+                                             dist_snat_entries,
+                                             mapping_dict)
+
         for hsi in host_snat_ips:
+            # Entries carrying distributed SNAT fields are consumed above.
+            # Skip legacy SNAT processing to avoid duplicate programming.
+            if any(k in hsi for k in ('start_port', 'end_port', 'service_ip',
+                                      'service_vrf', 'service_nodes',
+                                      'service_mac')):
+                continue
             LOG.debug("Auto-allocated host SNAT IP: %s", hsi)
             es = hsi.get('external_segment_name')
             if not es:


### PR DESCRIPTION
The agent consumes distributed SNAT information from gbp RPCs, creates SNAT and service configuration files for opflex-agent, tracks local and remote service node mappings, updates endpoint SNAT references, and reports allocated SNAT IP/port mappings through the dist_snat_mappings agent configuration field.