### PR TITLE
Add zone for distributed SNAT

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import hashlib
+import json
 import os
 import uuid
 
@@ -19,6 +20,8 @@ SNAT_FILE_EXTENSION = 'snat'
 SNAT_FILE_FORMAT = "%s." + SNAT_FILE_EXTENSION
 SERVICE_FILE_EXTENSION = 'service'
 SERVICE_FILE_FORMAT = "%s." + SERVICE_FILE_EXTENSION
+SNAT_CT_ZONE_MIN = 1
+SNAT_CT_ZONE_MAX = 65535
 
 
 class DistributedSnatManager(object):
@@ -41,6 +44,10 @@ class DistributedSnatManager(object):
         self._endpoint_to_snats = {}
         # snat_uuid -> {snat_ip,start,end}
         self._snat_to_ip_range = {}
+        # snat_ip -> conntrack zone
+        self._snat_ip_to_zone = {}
+        self._used_zones = set()
+        self._load_existing_snat_zones(snats_dir)
 
     def sync_endpoint(self, endpoint_uuid, dist_snat_entries, ep_mapping):
         old_snats = self._endpoint_to_snats.get(endpoint_uuid, set())
@@ -103,6 +110,55 @@ class DistributedSnatManager(object):
         self._delete_file(snat_uuid, self.snat_mapping_file)
         self._delete_file(snat_uuid, self.service_mapping_file)
 
+    def _load_existing_snat_zones(self, snats_dir):
+        if not os.path.isdir(snats_dir):
+            return
+
+        for filename in sorted(os.listdir(snats_dir)):
+            if not filename.endswith('.' + SNAT_FILE_EXTENSION):
+                continue
+
+            try:
+                with open(os.path.join(snats_dir, filename)) as snat_file:
+                    snat_mapping = json.load(snat_file)
+            except (IOError, TypeError, ValueError):
+                continue
+            if not isinstance(snat_mapping, dict):
+                continue
+
+            zone = self._safe_int(snat_mapping.get('zone'))
+            if not self._valid_zone(zone):
+                continue
+
+            snat_ip = snat_mapping.get('snat-ip')
+            if (snat_ip and snat_ip not in self._snat_ip_to_zone and
+                    zone not in self._used_zones):
+                self._snat_ip_to_zone[snat_ip] = zone
+            self._used_zones.add(zone)
+
+    def _valid_zone(self, zone):
+        return (zone is not None and
+                SNAT_CT_ZONE_MIN <= zone <= SNAT_CT_ZONE_MAX)
+
+    def _next_available_zone(self):
+        for zone in range(SNAT_CT_ZONE_MIN, SNAT_CT_ZONE_MAX + 1):
+            if zone not in self._used_zones:
+                return zone
+        raise RuntimeError("No distributed SNAT conntrack zones available")
+
+    def _zone_for_snat_ip(self, snat_ip):
+        if not snat_ip:
+            return None
+
+        zone = self._snat_ip_to_zone.get(snat_ip)
+        if zone is not None:
+            return zone
+
+        zone = self._next_available_zone()
+        self._snat_ip_to_zone[snat_ip] = zone
+        self._used_zones.add(zone)
+        return zone
+
     def _stable_dist_snat_uuid(self, hsi):
         seed = '%s|%s|%s' % (
             hsi.get('host_snat_ip', ''),
@@ -132,6 +188,7 @@ class DistributedSnatManager(object):
 
             snat_uuid = self._stable_dist_snat_uuid(hsi)
             service_mac = hsi.get('service_mac') or hsi.get('host_snat_mac')
+            snat_zone = self._zone_for_snat_ip(hsi.get('host_snat_ip'))
             service_nodes = []
             for node in hsi.get('service_nodes', []):
                 node_start = self._safe_int(node.get('start_port'))
@@ -155,6 +212,8 @@ class DistributedSnatManager(object):
             }
             if interface_vlan is not None:
                 snat_file['interface-vlan'] = interface_vlan
+            if snat_zone is not None:
+                snat_file['zone'] = snat_zone
 
             service_file = {
                 'uuid': snat_uuid,

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -45,17 +45,40 @@ class TestDistributedSnatManager(base.OpflexTestBase):
             except OSError:
                 pass
 
-        self.mgr = distributed_snat_manager.DistributedSnatManager(
+        self._write = _write
+        self._delete = _delete
+        self.mgr = self._new_manager()
+
+    def _new_manager(self):
+        return distributed_snat_manager.DistributedSnatManager(
             os.path.join(self.tmp_root, 'snats'),
             os.path.join(self.tmp_root, 'service'),
-            _write,
-            _delete)
+            self._write,
+            self._delete)
 
     def _cleanup(self):
         try:
             shutil.rmtree(self.tmp_root)
         except OSError:
             pass
+
+    def _dist_snat_mapping(self, host_snat_ips=None):
+        host_snat_ips = host_snat_ips or [{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'dest_prefix': '0.0.0.0/0',
+        }]
+        return {
+            'host_snat_ips': host_snat_ips,
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
 
     def test_sync_endpoint_writes_files_and_ep_uuid_refs(self):
         ep_mapping = {}
@@ -112,26 +135,22 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual({}, self.mgr.get_dist_snat_mappings())
 
     def test_build_dist_snat_entries_from_host_snat_ips(self):
-        mapping = {
-            'host_snat_ips': [{
-                'external_segment_name': 'EXT-DIST',
-                'host_snat_ip': '200.0.0.50',
-                'host_snat_mac': 'aa:bb:cc:00:11:55',
-                'service_mac': 'aa:bb:cc:00:22:66',
-                'start_port': 10000,
-                'end_port': 10999,
-                'service_ip': '10.99.0.1',
-                'service_vrf': 'vrf-svc',
-                'dest_prefix': '0.0.0.0/0',
-                'service_nodes': [{
-                    'mac': 'dd:ee:ff:00:11:22',
-                    'start_port': 20000,
-                    'end_port': 20999,
-                }],
+        mapping = self._dist_snat_mapping([{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'dest_prefix': '0.0.0.0/0',
+            'service_nodes': [{
+                'mac': 'dd:ee:ff:00:11:22',
+                'start_port': 20000,
+                'end_port': 20999,
             }],
-            'vrf_tenant': 'apic_tenant',
-            'vrf_name': 'name_of_l3p',
-        }
+        }])
         mapping_dict = {'interface-name': 'qpi'}
 
         entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
@@ -147,7 +166,48 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                          entry['snat_file']['interface-mac'])
         self.assertEqual([{'start': 10000, 'end': 10999}],
                          entry['snat_file']['port-range'])
+        self.assertEqual(1, entry['snat_file']['zone'])
         self.assertEqual('apic_tenant',
                          entry['service_file']['domain-policy-space'])
         self.assertEqual('vrf-svc', entry['service_file']['domain-name'])
         self.assertEqual('10.99.0.1', entry['service_file']['interface-ip'])
+
+    def test_build_dist_snat_entries_assigns_unique_zone_per_snat_ip(self):
+        mapping = self._dist_snat_mapping([
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+            },
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.51',
+                'host_snat_mac': 'aa:bb:cc:00:11:56',
+                'start_port': 11000,
+                'end_port': 11999,
+                'service_ip': '10.99.0.2',
+            },
+        ])
+
+        entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+
+        zones = [x['snat_file']['zone'] for x in entries]
+        self.assertEqual([1, 2], zones)
+
+    def test_build_dist_snat_entries_reuses_zone_from_snat_file(self):
+        mapping = self._dist_snat_mapping()
+        mapping_dict = {'interface-name': 'qpi'}
+        entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff', entries, {})
+
+        restarted_mgr = self._new_manager()
+
+        restarted_entries = restarted_mgr.build_dist_snat_entries(
+            mapping, mapping_dict)
+
+        self.assertEqual(entries[0]['snat_file']['zone'],
+                         restarted_entries[0]['snat_file']['zone'])


### PR DESCRIPTION
Commit 9362781 added distributed SNAT support to the agent, but did not add connection tracking zone allocation or configuration. This patch adds support for connection tracking zone management for distributed SNAT.