### PR TITLE
Add distributed SNAT interface configuration

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -36,6 +36,10 @@ gbp_opts = [
                default=8191,
                help=_("Maximum conntrack zone number to allocate for "
                       "distributed SNAT.")),
+    cfg.StrOpt('distributed_snat_interface',
+               default='patch-fab-ex',
+               help=_("Interface name to use in distributed SNAT and "
+                      "service mapping files.")),
     cfg.StrOpt('opflex_agent_dir',
                default='/var/lib/neutron/opflex_agent',
                help=_("Directory where the opflex agent state will be "

--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -33,7 +33,8 @@ class DistributedSnatManager(object):
 
     def __init__(self, snats_dir, service_dir, write_fn, delete_fn,
                  zone_min=SNAT_CT_ZONE_MIN,
-                 zone_max=SNAT_CT_ZONE_MAX):
+                 zone_max=SNAT_CT_ZONE_MAX,
+                 distributed_snat_interface='patch-fab-ex'):
         self.snat_mapping_file = os.path.join(snats_dir, SNAT_FILE_FORMAT)
         self.service_mapping_file = os.path.join(service_dir,
                                                  SERVICE_FILE_FORMAT)
@@ -48,6 +49,7 @@ class DistributedSnatManager(object):
         if self.zone_min > self.zone_max:
             self.zone_min = SNAT_CT_ZONE_MIN
             self.zone_max = SNAT_CT_ZONE_MAX
+        self.distributed_snat_interface = distributed_snat_interface
 
         # snat_uuid -> set(endpoint_uuid)
         self._snat_to_endpoints = {}
@@ -223,7 +225,7 @@ class DistributedSnatManager(object):
     def build_dist_snat_entries(self, mapping, mapping_dict):
         dist_entries = []
         host_snat_ips = mapping.get('host_snat_ips', [])
-        interface_name = mapping_dict.get('interface-name')
+        interface_name = self.distributed_snat_interface
         fallback_service_domain = mapping.get('vrf_tenant', 'common')
 
         for hsi in host_snat_ips:

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -637,6 +637,8 @@ def create_agent_config_map(conf):
         conf.OPFLEX.distributed_snat_zone_min)
     agent_config['distributed_snat_zone_max'] = (
         conf.OPFLEX.distributed_snat_zone_max)
+    agent_config['distributed_snat_interface'] = (
+        conf.OPFLEX.distributed_snat_interface)
     agent_config['opflex_networks'] = conf.OPFLEX.opflex_networks
     agent_config['vlan_networks'] = conf.OPFLEX.vlan_networks
     agent_config['endpoint_request_timeout'] = (

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -177,7 +177,8 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual('200.0.0.50', entry['snat_ip'])
         self.assertEqual(10000, entry['start'])
         self.assertEqual(10999, entry['end'])
-        self.assertEqual('qpi', entry['snat_file']['interface-name'])
+        self.assertEqual('patch-fab-ex',
+                         entry['snat_file']['interface-name'])
         self.assertEqual('200.0.0.50', entry['snat_file']['snat-ip'])
         self.assertEqual(10, entry['snat_file']['interface-vlan'])
         self.assertEqual('aa:bb:cc:00:22:66',
@@ -321,3 +322,29 @@ class TestDistributedSnatManager(base.OpflexTestBase):
 
         zones = [x['snat_file']['zone'] for x in entries]
         self.assertEqual([4000, 4001], zones)
+
+    def test_build_dist_snat_entries_uses_configured_interface(self):
+        self.mgr.distributed_snat_interface = 'dist-snat-if'
+        mapping = {
+            'host_snat_ips': [{
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+                'service_vrf': 'vrf-svc',
+            }],
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
+        mapping_dict = {'interface-name': 'qpi'}
+
+        entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
+
+        self.assertEqual(1, len(entries))
+        entry = entries[0]
+        self.assertEqual('dist-snat-if',
+                         entry['snat_file']['interface-name'])
+        self.assertEqual('dist-snat-if',
+                         entry['service_file']['interface-name'])

--- a/opflexagent/test/test_endpoint_file_manager.py
+++ b/opflexagent/test/test_endpoint_file_manager.py
@@ -66,6 +66,13 @@ class TestEndpointFileManager(base.OpflexTestBase):
             return_value=('qpi', 'qpf')))
         return agent
 
+    def test_agent_config_includes_distributed_snat_interface(self):
+        cfg.CONF.set_override('distributed_snat_interface',
+                              'dist-snat-if', 'OPFLEX')
+        kwargs = gbp_agent.create_agent_config_map(cfg.CONF)
+        self.assertEqual('dist-snat-if',
+                         kwargs['distributed_snat_interface'])
+
     def _mock_agent(self, agent):
         agent._write_endpoint_file = mock.Mock(
             return_value=agent.epg_mapping_file)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -107,7 +107,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     self._write_file,
                     self._delete_file,
                     zone_min=config.get('distributed_snat_zone_min', 1000),
-                    zone_max=config.get('distributed_snat_zone_max', 8191)))
+                    zone_max=config.get('distributed_snat_zone_max', 8191),
+                    config.get('distributed_snat_interface',
+                               'patch-fab-ex')))
         self._registered_endpoints = set()
         self._stale_endpoints = set()
         self.vif_int_dict = {}


### PR DESCRIPTION
The interface that the agent should use for distributed SNAT should come from configuration, as this is really specific to the installation, and not to any generated configuration.