### PR TITLE
Fix distributed SNAT UUIDs

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -41,6 +41,8 @@ class DistributedSnatManager(object):
         self._endpoint_to_snats = {}
         # snat_uuid -> {snat_ip,start,end}
         self._snat_to_ip_range = {}
+        # snat_uuid -> service_uuid
+        self._snat_to_service = {}
 
     def sync_endpoint(self, endpoint_uuid, dist_snat_entries, ep_mapping):
         old_snats = self._endpoint_to_snats.get(endpoint_uuid, set())
@@ -63,7 +65,16 @@ class DistributedSnatManager(object):
                 self._write_file(snat_uuid, entry['snat_file'],
                                  self.snat_mapping_file)
             if entry.get('service_file'):
-                self._write_file(snat_uuid, entry['service_file'],
+                service_uuid = entry['service_file'].get('uuid', snat_uuid)
+                old_service_uuid = self._snat_to_service.get(snat_uuid)
+                if old_service_uuid and old_service_uuid != service_uuid:
+                    self._delete_file(old_service_uuid,
+                                      self.service_mapping_file)
+                if (service_uuid != snat_uuid and
+                        old_service_uuid != snat_uuid):
+                    self._delete_file(snat_uuid, self.service_mapping_file)
+                self._snat_to_service[snat_uuid] = service_uuid
+                self._write_file(service_uuid, entry['service_file'],
                                  self.service_mapping_file)
 
         for snat_uuid in (old_snats - new_snats):
@@ -100,14 +111,17 @@ class DistributedSnatManager(object):
 
         self._snat_to_endpoints.pop(snat_uuid, None)
         self._snat_to_ip_range.pop(snat_uuid, None)
+        service_uuid = self._snat_to_service.pop(snat_uuid, snat_uuid)
         self._delete_file(snat_uuid, self.snat_mapping_file)
-        self._delete_file(snat_uuid, self.service_mapping_file)
+        self._delete_file(service_uuid, self.service_mapping_file)
 
-    def _stable_dist_snat_uuid(self, hsi):
+    def _stable_dist_snat_uuid(self, hsi, kind=None):
         seed = '%s|%s|%s' % (
             hsi.get('host_snat_ip', ''),
             hsi.get('external_segment_name', ''),
             hsi.get('service_ip', ''))
+        if kind:
+            seed = '%s|%s' % (kind, seed)
         digest = hashlib.md5(seed.encode('utf-8')).hexdigest()
         return str(uuid.UUID(digest))
 
@@ -131,6 +145,7 @@ class DistributedSnatManager(object):
                 continue
 
             snat_uuid = self._stable_dist_snat_uuid(hsi)
+            service_uuid = self._stable_dist_snat_uuid(hsi, 'service')
             service_mac = hsi.get('service_mac') or hsi.get('host_snat_mac')
             service_nodes = []
             for node in hsi.get('service_nodes', []):
@@ -157,7 +172,7 @@ class DistributedSnatManager(object):
                 snat_file['interface-vlan'] = interface_vlan
 
             service_file = {
-                'uuid': snat_uuid,
+                'uuid': service_uuid,
                 'domain-policy-space': service_domain,
                 'domain-name': (
                     hsi.get('service_vrf') or

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -69,9 +69,17 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                 'snat-ip': '66.66.66.7',
                 'port-range': [{'start': 100, 'end': 199}]},
             'service_file': {
-                'uuid': '00000000-0000-0000-0000-ffff980a0114',
+                'uuid': '00000000-0000-0000-0000-ffff980a0115',
                 'interface-ip': '16.5.168.7'}
         }
+
+        old_service_file = os.path.join(
+            self.tmp_root, 'service',
+            '00000000-0000-0000-0000-ffff980a0114.service')
+        if not os.path.exists(os.path.dirname(old_service_file)):
+            os.makedirs(os.path.dirname(old_service_file))
+        with open(old_service_file, 'w') as f:
+            json.dump({'uuid': dist_entry['uuid']}, f)
 
         self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff',
                                [dist_entry],
@@ -87,9 +95,10 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                                  '00000000-0000-0000-0000-ffff980a0114.snat')
         service_file = os.path.join(
             self.tmp_root, 'service',
-            '00000000-0000-0000-0000-ffff980a0114.service')
+            '00000000-0000-0000-0000-ffff980a0115.service')
         self.assertTrue(os.path.exists(snat_file))
         self.assertTrue(os.path.exists(service_file))
+        self.assertFalse(os.path.exists(old_service_file))
 
     def test_cleanup_port_deletes_files_when_last_endpoint_removed(self):
         dist_entry = {
@@ -151,3 +160,12 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                          entry['service_file']['domain-policy-space'])
         self.assertEqual('vrf-svc', entry['service_file']['domain-name'])
         self.assertEqual('10.99.0.1', entry['service_file']['interface-ip'])
+        self.assertEqual(entry['uuid'], entry['snat_file']['uuid'])
+        self.assertNotEqual(entry['snat_file']['uuid'],
+                            entry['service_file']['uuid'])
+
+        new_entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
+        self.assertEqual(entry['snat_file']['uuid'],
+                         new_entries[0]['snat_file']['uuid'])
+        self.assertEqual(entry['service_file']['uuid'],
+                         new_entries[0]['service_file']['uuid'])


### PR DESCRIPTION
Commit 9362781 added support for distributed SNAT to the agent. However, the .service file and .snat file used the same UUID, which resulted in the opflex-agent overwriting the flow-mods based on which file was the last one updated.

This patch ensures that the .service and .snat files use their own UUIDs, so that the opflex-agent keeps flows for both.