### PR TITLE
Add distributed SNAT conntrack zone management

### DIFF
--- a/opflexagent/config.py
+++ b/opflexagent/config.py
@@ -28,6 +28,14 @@ gbp_opts = [
                default='/var/lib/opflex-agent-ovs/snats/',
                help=_("Directory where distributed SNAT mapping files will "
                       "be stored.")),
+    cfg.IntOpt('distributed_snat_zone_min',
+               default=1000,
+               help=_("Minimum conntrack zone number to allocate for "
+                      "distributed SNAT.")),
+    cfg.IntOpt('distributed_snat_zone_max',
+               default=8191,
+               help=_("Maximum conntrack zone number to allocate for "
+                      "distributed SNAT.")),
     cfg.StrOpt('opflex_agent_dir',
                default='/var/lib/neutron/opflex_agent',
                help=_("Directory where the opflex agent state will be "

--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import hashlib
+import json
 import os
 import uuid
 
@@ -19,6 +20,8 @@ SNAT_FILE_EXTENSION = 'snat'
 SNAT_FILE_FORMAT = "%s." + SNAT_FILE_EXTENSION
 SERVICE_FILE_EXTENSION = 'service'
 SERVICE_FILE_FORMAT = "%s." + SERVICE_FILE_EXTENSION
+SNAT_CT_ZONE_MIN = 1000
+SNAT_CT_ZONE_MAX = 8191
 
 
 class DistributedSnatManager(object):
@@ -28,12 +31,23 @@ class DistributedSnatManager(object):
     endpoint manager file writer/delete helpers for all filesystem updates.
     """
 
-    def __init__(self, snats_dir, service_dir, write_fn, delete_fn):
+    def __init__(self, snats_dir, service_dir, write_fn, delete_fn,
+                 zone_min=SNAT_CT_ZONE_MIN,
+                 zone_max=SNAT_CT_ZONE_MAX):
         self.snat_mapping_file = os.path.join(snats_dir, SNAT_FILE_FORMAT)
         self.service_mapping_file = os.path.join(service_dir,
                                                  SERVICE_FILE_FORMAT)
         self._write_file = write_fn
         self._delete_file = delete_fn
+        self.zone_min = zone_min
+        self.zone_max = zone_max
+        if self.zone_min is None or self.zone_min < SNAT_CT_ZONE_MIN:
+            self.zone_min = SNAT_CT_ZONE_MIN
+        if self.zone_max is None or self.zone_max > SNAT_CT_ZONE_MAX:
+            self.zone_max = SNAT_CT_ZONE_MAX
+        if self.zone_min > self.zone_max:
+            self.zone_min = SNAT_CT_ZONE_MIN
+            self.zone_max = SNAT_CT_ZONE_MAX
 
         # snat_uuid -> set(endpoint_uuid)
         self._snat_to_endpoints = {}
@@ -43,6 +57,10 @@ class DistributedSnatManager(object):
         self._snat_to_ip_range = {}
         # snat_uuid -> service_uuid
         self._snat_to_service = {}
+        # snat_ip -> conntrack zone
+        self._snat_ip_to_zone = {}
+        self._used_zones = set()
+        self._load_existing_snat_zones(snats_dir)
 
     def sync_endpoint(self, endpoint_uuid, dist_snat_entries, ep_mapping):
         old_snats = self._endpoint_to_snats.get(endpoint_uuid, set())
@@ -110,10 +128,74 @@ class DistributedSnatManager(object):
             return
 
         self._snat_to_endpoints.pop(snat_uuid, None)
-        self._snat_to_ip_range.pop(snat_uuid, None)
+        snat_info = self._snat_to_ip_range.pop(snat_uuid, None)
+        snat_ip = (snat_info.get('snat_ip')
+               if isinstance(snat_info, dict) else None)
         service_uuid = self._snat_to_service.pop(snat_uuid, snat_uuid)
         self._delete_file(snat_uuid, self.snat_mapping_file)
         self._delete_file(service_uuid, self.service_mapping_file)
+        self._release_zone_for_snat_ip(snat_ip)
+
+    def _release_zone_for_snat_ip(self, snat_ip):
+        if not snat_ip:
+            return
+
+        if any(info.get('snat_ip') == snat_ip
+               for info in list(self._snat_to_ip_range.values())):
+            return
+
+        zone = self._snat_ip_to_zone.pop(snat_ip, None)
+        if zone is not None:
+            self._used_zones.discard(zone)
+
+    def _load_existing_snat_zones(self, snats_dir):
+        if not os.path.isdir(snats_dir):
+            return
+
+        for filename in sorted(os.listdir(snats_dir)):
+            if not filename.endswith('.' + SNAT_FILE_EXTENSION):
+                continue
+
+            try:
+                with open(os.path.join(snats_dir, filename)) as snat_file:
+                    snat_mapping = json.load(snat_file)
+            except (IOError, TypeError, ValueError):
+                continue
+            if not isinstance(snat_mapping, dict):
+                continue
+
+            zone = self._safe_int(snat_mapping.get('zone'))
+            if not self._valid_zone(zone):
+                continue
+
+            snat_ip = snat_mapping.get('snat-ip')
+            if (snat_ip and snat_ip not in self._snat_ip_to_zone and
+                    zone not in self._used_zones):
+                self._snat_ip_to_zone[snat_ip] = zone
+            self._used_zones.add(zone)
+
+    def _valid_zone(self, zone):
+        return (zone is not None and
+                self.zone_min <= zone <= self.zone_max)
+
+    def _next_available_zone(self):
+        for zone in range(self.zone_min, self.zone_max + 1):
+            if zone not in self._used_zones:
+                return zone
+        raise RuntimeError("No distributed SNAT conntrack zones available")
+
+    def _zone_for_snat_ip(self, snat_ip):
+        if not snat_ip:
+            return None
+
+        zone = self._snat_ip_to_zone.get(snat_ip)
+        if zone is not None:
+            return zone
+
+        zone = self._next_available_zone()
+        self._snat_ip_to_zone[snat_ip] = zone
+        self._used_zones.add(zone)
+        return zone
 
     def _stable_dist_snat_uuid(self, hsi, kind=None):
         seed = '%s|%s|%s' % (
@@ -156,6 +238,7 @@ class DistributedSnatManager(object):
             snat_uuid = self._stable_dist_snat_uuid(hsi)
             service_uuid = self._stable_dist_snat_uuid(hsi, 'service')
             service_mac = hsi.get('service_mac') or hsi.get('host_snat_mac')
+            snat_zone = self._zone_for_snat_ip(hsi.get('host_snat_ip'))
             service_nodes = []
             for node in hsi.get('service_nodes', []):
                 node_start = self._safe_int(node.get('start_port'))
@@ -179,6 +262,8 @@ class DistributedSnatManager(object):
             }
             if interface_vlan is not None:
                 snat_file['interface-vlan'] = interface_vlan
+            if snat_zone is not None:
+                snat_file['zone'] = snat_zone
 
             service_file = {
                 'uuid': service_uuid,

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -633,6 +633,10 @@ def create_agent_config_map(conf):
     agent_config['epg_mapping_dir'] = conf.OPFLEX.epg_mapping_dir
     agent_config['as_mapping_dir'] = conf.OPFLEX.as_mapping_dir
     agent_config['snats_mapping_dir'] = conf.OPFLEX.snats_mapping_dir
+    agent_config['distributed_snat_zone_min'] = (
+        conf.OPFLEX.distributed_snat_zone_min)
+    agent_config['distributed_snat_zone_max'] = (
+        conf.OPFLEX.distributed_snat_zone_max)
     agent_config['opflex_networks'] = conf.OPFLEX.opflex_networks
     agent_config['vlan_networks'] = conf.OPFLEX.vlan_networks
     agent_config['endpoint_request_timeout'] = (

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -45,17 +45,42 @@ class TestDistributedSnatManager(base.OpflexTestBase):
             except OSError:
                 pass
 
-        self.mgr = distributed_snat_manager.DistributedSnatManager(
+        self._write = _write
+        self._delete = _delete
+        self.mgr = self._new_manager()
+
+    def _new_manager(self, zone_min=None, zone_max=None):
+        return distributed_snat_manager.DistributedSnatManager(
             os.path.join(self.tmp_root, 'snats'),
             os.path.join(self.tmp_root, 'service'),
-            _write,
-            _delete)
+            self._write,
+            self._delete,
+            zone_min=zone_min,
+            zone_max=zone_max)
 
     def _cleanup(self):
         try:
             shutil.rmtree(self.tmp_root)
         except OSError:
             pass
+
+    def _dist_snat_mapping(self, host_snat_ips=None):
+        host_snat_ips = host_snat_ips or [{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'dest_prefix': '0.0.0.0/0',
+        }]
+        return {
+            'host_snat_ips': host_snat_ips,
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
 
     def test_sync_endpoint_writes_files_and_ep_uuid_refs(self):
         ep_mapping = {}
@@ -161,6 +186,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                          entry['service_file']['domain-policy-space'])
         self.assertEqual('vrf-svc', entry['service_file']['domain-name'])
         self.assertEqual('10.99.0.1', entry['service_file']['interface-ip'])
+        self.assertEqual(1000, entry['snat_file']['zone'])
         self.assertEqual(entry['uuid'], entry['snat_file']['uuid'])
         self.assertNotEqual(entry['snat_file']['uuid'],
                             entry['service_file']['uuid'])
@@ -194,3 +220,101 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual(
             'snat_tenant',
             entries[0]['service_file']['domain-policy-space'])
+
+    def test_build_dist_snat_entries_assigns_unique_zone_per_snat_ip(self):
+        mapping = self._dist_snat_mapping([
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+            },
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.51',
+                'host_snat_mac': 'aa:bb:cc:00:11:56',
+                'start_port': 11000,
+                'end_port': 11999,
+                'service_ip': '10.99.0.2',
+            },
+        ])
+
+        entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+
+        zones = [x['snat_file']['zone'] for x in entries]
+        self.assertEqual([1000, 1001], zones)
+
+    def test_build_dist_snat_entries_reuses_zone_from_snat_file(self):
+        mapping = self._dist_snat_mapping()
+        mapping_dict = {'interface-name': 'qpi'}
+        entries = self.mgr.build_dist_snat_entries(mapping, mapping_dict)
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff', entries, {})
+
+        restarted_mgr = self._new_manager()
+
+        restarted_entries = restarted_mgr.build_dist_snat_entries(
+            mapping, mapping_dict)
+
+        self.assertEqual(entries[0]['snat_file']['zone'],
+                         restarted_entries[0]['snat_file']['zone'])
+
+    def test_build_dist_snat_entries_reuses_zone_after_cleanup(self):
+        mapping1 = self._dist_snat_mapping([{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+        }])
+        mapping2 = self._dist_snat_mapping([{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.51',
+            'host_snat_mac': 'aa:bb:cc:00:11:56',
+            'start_port': 11000,
+            'end_port': 11999,
+            'service_ip': '10.99.0.2',
+        }])
+        mapping_dict = {'interface-name': 'qpi'}
+
+        first_entries = self.mgr.build_dist_snat_entries(mapping1,
+                                                         mapping_dict)
+        self.assertEqual(1000, first_entries[0]['snat_file']['zone'])
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff',
+                               first_entries, {})
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff', [], {})
+
+        second_entries = self.mgr.build_dist_snat_entries(mapping2,
+                                                          mapping_dict)
+        self.assertEqual(1000, second_entries[0]['snat_file']['zone'])
+
+    def test_build_dist_snat_entries_uses_configured_zone_range(self):
+        self.mgr = self._new_manager(zone_min=4000, zone_max=4002)
+
+        mapping = self._dist_snat_mapping([
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+            },
+            {
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.51',
+                'host_snat_mac': 'aa:bb:cc:00:11:56',
+                'start_port': 11000,
+                'end_port': 11999,
+                'service_ip': '10.99.0.2',
+            },
+        ])
+
+        entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+
+        zones = [x['snat_file']['zone'] for x in entries]
+        self.assertEqual([4000, 4001], zones)

--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -105,7 +105,9 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
                     config['snats_mapping_dir'],
                     config['as_mapping_dir'],
                     self._write_file,
-                    self._delete_file))
+                    self._delete_file,
+                    zone_min=config.get('distributed_snat_zone_min', 1000),
+                    zone_max=config.get('distributed_snat_zone_max', 8191)))
         self._registered_endpoints = set()
         self._stale_endpoints = set()
         self.vif_int_dict = {}


### PR DESCRIPTION
Commit 9362781 added distributed SNAT support but did not manage conntrack zones. Implement conntrack zone allocation for distributed SNAT, persist and restore zone assignments across restart, and reuse zones after cleanup of the last SNAT reference. Add configurable zone min/max range with safer defaults to avoid low zone IDs. Update tests for allocation, restart reuse, cleanup reuse, and configurable range.