### PR TITLE
Fix distributed SNAT VLAN

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -224,7 +224,6 @@ class DistributedSnatManager(object):
         dist_entries = []
         host_snat_ips = mapping.get('host_snat_ips', [])
         interface_name = mapping_dict.get('interface-name')
-        interface_vlan = mapping_dict.get('access-interface-vlan')
         fallback_service_domain = mapping.get('vrf_tenant', 'common')
 
         for hsi in host_snat_ips:
@@ -260,8 +259,8 @@ class DistributedSnatManager(object):
                 'port-range': [{'start': start, 'end': end}],
                 'remote': service_nodes,
             }
-            if interface_vlan is not None:
-                snat_file['interface-vlan'] = interface_vlan
+            if hsi['service_vlan'] is not None:
+                snat_file['interface-vlan'] = hsi['service_vlan']
             if snat_zone is not None:
                 snat_file['zone'] = snat_zone
 
@@ -282,8 +281,8 @@ class DistributedSnatManager(object):
                     'conntrack-enabled': True,
                 }]
             }
-            if interface_vlan is not None:
-                service_file['interface-vlan'] = interface_vlan
+            if hsi['service_vlan'] is not None:
+                service_file['interface-vlan'] = hsi['service_vlan']
 
             dist_entries.append({
                 'uuid': snat_uuid,

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -157,6 +157,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                 'end_port': 10999,
                 'service_ip': '10.99.0.1',
                 'service_vrf': 'vrf-svc',
+                'service_vlan': 10,
                 'dest_prefix': '0.0.0.0/0',
                 'service_nodes': [{
                     'mac': 'dd:ee:ff:00:11:22',
@@ -178,6 +179,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual(10999, entry['end'])
         self.assertEqual('qpi', entry['snat_file']['interface-name'])
         self.assertEqual('200.0.0.50', entry['snat_file']['snat-ip'])
+        self.assertEqual(10, entry['snat_file']['interface-vlan'])
         self.assertEqual('aa:bb:cc:00:22:66',
                          entry['snat_file']['interface-mac'])
         self.assertEqual([{'start': 10000, 'end': 10999}],
@@ -185,6 +187,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual('common',
                          entry['service_file']['domain-policy-space'])
         self.assertEqual('vrf-svc', entry['service_file']['domain-name'])
+        self.assertEqual(10, entry['service_file']['interface-vlan'])
         self.assertEqual('10.99.0.1', entry['service_file']['interface-ip'])
         self.assertEqual(1000, entry['snat_file']['zone'])
         self.assertEqual(entry['uuid'], entry['snat_file']['uuid'])


### PR DESCRIPTION
The VLAN ID for distributed SNAT is needed for the service and SNAT files. This patch gets the VLAN from the Host SNAT IPs (hsi) field, which is passed via RPCs to the endpoint manager.

(cherry picked from commit 65d07e4f0c9a7b95f4a1acb56bc6df1d03e1b87e) (cherry picked from commit de788481a6267700cfce1f34d8ab069bb59c1feb) (cherry picked from commit 77369e41adc9dab3fa122bfa78a5fc9295c10a1e) (cherry picked from commit 1954171516dc9dd2cef6ac426459984e0117f0fe) (cherry picked from commit f7a215b7b96e950ac56698032bc14723da2a2001) (cherry picked from commit 801640471debddfa594d962cfc424c1a1ca848e3) (cherry picked from commit c84c5f2092d917ea99699b3643f8aa6a2da1d043) (cherry picked from commit 54e168dccaf300fd0c79756bfa0446267772de0d)