### PR TITLE
Use single zone for connection tracking

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -276,7 +276,13 @@ class DistributedSnatManager(object):
             if hsi['service_vlan'] is not None:
                 snat_file['interface-vlan'] = hsi['service_vlan']
             if snat_zone is not None:
-                snat_file['zone'] = snat_zone
+                # TODO(thbachma): Once the agent is fixed to
+                # support multiple connection tracking zones
+                # for distributed snat, use the allocated zone.
+                # Until then, we have to use the same hard-coded
+                # value ocross all hosts (use the minimum value,
+                # so worst-case it's still configurable).
+                snat_file['zone'] = self.zone_min
 
             service_file = {
                 'uuid': service_uuid,

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -16,6 +16,7 @@
 import json
 import os
 import shutil
+import unittest
 
 from oslo_utils import uuidutils
 
@@ -298,6 +299,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
             'snat_tenant',
             entries[0]['service_file']['domain-policy-space'])
 
+    @unittest.skip("Restore for connection tracking zone support")
     def test_build_dist_snat_entries_assigns_unique_zone_per_snat_ip(self):
         mapping = self._dist_snat_mapping([
             {
@@ -372,6 +374,7 @@ class TestDistributedSnatManager(base.OpflexTestBase):
                                                           mapping_dict)
         self.assertEqual(1000, second_entries[0]['snat_file']['zone'])
 
+    @unittest.skip("Restore for connection tracking zone support")
     def test_build_dist_snat_entries_uses_configured_zone_range(self):
         self.mgr = self._new_manager(zone_min=4000, zone_max=4002)
 


### PR DESCRIPTION
The agent currently only supports a single connection tracking zone for distributed SNAT. This means a single zone has to be used across all SNAT files.