### PR TITLE
Fix distributed SNAT UUID usage

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -87,11 +87,15 @@ class DistributedSnatManager(object):
             if entry.get('service_file'):
                 service_uuid = entry['service_file'].get('uuid', snat_uuid)
                 old_service_uuid = self._snat_to_service.get(snat_uuid)
-                if old_service_uuid and old_service_uuid != service_uuid:
+                if (old_service_uuid and old_service_uuid != service_uuid and
+                        not self._service_file_is_referenced(
+                            old_service_uuid, ignored_snat_uuid=snat_uuid)):
                     self._delete_file(old_service_uuid,
                                       self.service_mapping_file)
                 if (service_uuid != snat_uuid and
-                        old_service_uuid != snat_uuid):
+                        old_service_uuid != snat_uuid and
+                        not self._service_file_is_referenced(
+                            snat_uuid, ignored_snat_uuid=snat_uuid)):
                     self._delete_file(snat_uuid, self.service_mapping_file)
                 self._snat_to_service[snat_uuid] = service_uuid
                 self._write_file(service_uuid, entry['service_file'],
@@ -135,8 +139,15 @@ class DistributedSnatManager(object):
                if isinstance(snat_info, dict) else None)
         service_uuid = self._snat_to_service.pop(snat_uuid, snat_uuid)
         self._delete_file(snat_uuid, self.snat_mapping_file)
-        self._delete_file(service_uuid, self.service_mapping_file)
+        if not self._service_file_is_referenced(service_uuid):
+            self._delete_file(service_uuid, self.service_mapping_file)
         self._release_zone_for_snat_ip(snat_ip)
+
+    def _service_file_is_referenced(self, service_uuid,
+                                    ignored_snat_uuid=None):
+        return any(
+            snat_uuid != ignored_snat_uuid and mapped_uuid == service_uuid
+            for snat_uuid, mapped_uuid in self._snat_to_service.items())
 
     def _release_zone_for_snat_ip(self, snat_ip):
         if not snat_ip:
@@ -236,7 +247,8 @@ class DistributedSnatManager(object):
             if start is None or end is None:
                 continue
 
-            snat_uuid = self._stable_dist_snat_uuid(hsi)
+            snat_uuid = (hsi.get('snat_uuid') or
+                         self._stable_dist_snat_uuid(hsi))
             service_uuid = self._stable_dist_snat_uuid(hsi, 'service')
             service_mac = hsi.get('service_mac') or hsi.get('host_snat_mac')
             snat_zone = self._zone_for_snat_ip(hsi.get('host_snat_ip'))

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -202,6 +202,77 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual(entry['service_file']['uuid'],
                          new_entries[0]['service_file']['uuid'])
 
+    def test_build_dist_snat_entries_uses_rpc_snat_uuid(self):
+        requested_snat_uuid = '11111111-2222-3333-4444-555555555555'
+        mapping = {
+            'host_snat_ips': [{
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'service_mac': 'aa:bb:cc:00:22:66',
+                'service_vlan': 10,
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+                'service_vrf': 'vrf-svc',
+                'service_vlan': 10,
+                'snat_uuid': requested_snat_uuid,
+            }],
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
+
+        entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+
+        self.assertEqual(requested_snat_uuid, entries[0]['uuid'])
+        self.assertEqual(requested_snat_uuid, entries[0]['snat_file']['uuid'])
+
+    def test_sync_endpoint_preserves_service_file_when_snat_uuid_changes(self):
+        requested_snat_uuid = '11111111-2222-3333-4444-555555555555'
+        endpoint_uuid = 'port-id|aa-bb-cc-dd-ee-ff'
+        mapping = {
+            'host_snat_ips': [{
+                'external_segment_name': 'EXT-DIST',
+                'host_snat_ip': '200.0.0.50',
+                'host_snat_mac': 'aa:bb:cc:00:11:55',
+                'service_mac': 'aa:bb:cc:00:22:66',
+                'service_vlan': 10,
+                'start_port': 10000,
+                'end_port': 10999,
+                'service_ip': '10.99.0.1',
+                'service_vrf': 'vrf-svc',
+                'service_vlan': 10,
+            }],
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
+        mapping_dict = {'interface-name': 'qpi'}
+
+        generated_entries = self.mgr.build_dist_snat_entries(
+            mapping, mapping_dict)
+        generated_snat_uuid = generated_entries[0]['uuid']
+        service_uuid = generated_entries[0]['service_file']['uuid']
+        self.mgr.sync_endpoint(endpoint_uuid, generated_entries, {})
+
+        mapping['host_snat_ips'][0]['snat_uuid'] = requested_snat_uuid
+        requested_entries = self.mgr.build_dist_snat_entries(
+            mapping, mapping_dict)
+        self.assertEqual(service_uuid,
+                         requested_entries[0]['service_file']['uuid'])
+
+        self.mgr.sync_endpoint(endpoint_uuid, requested_entries, {})
+
+        generated_snat_file = os.path.join(
+            self.tmp_root, 'snats', '%s.snat' % generated_snat_uuid)
+        requested_snat_file = os.path.join(
+            self.tmp_root, 'snats', '%s.snat' % requested_snat_uuid)
+        service_file = os.path.join(
+            self.tmp_root, 'service', '%s.service' % service_uuid)
+        self.assertFalse(os.path.exists(generated_snat_file))
+        self.assertTrue(os.path.exists(requested_snat_file))
+        self.assertTrue(os.path.exists(service_file))
+
     def test_build_dist_snat_entries_uses_non_common_external_segment_tenant(
             self):
         mapping = {


### PR DESCRIPTION
Use the "snat_uuid" parameter passed in the host_snat_ips part of the request_endpoint_details RPC for the SNAT UUID files. This makes debugging in the field simpler, as it's easier to relate SNAT IPs to a distribute SNAT subnet.

(cherry picked from commit 18f7ca713f93da447d30dd37fa1c46ad984aeab5) (cherry picked from commit be57a26d3d154caab3cfb23f06ef406bfdfd4754) (cherry picked from commit 7398a4921c5841f770a10d4fec0ded10d2b5d1dc) (cherry picked from commit facd437b62112ebbaff850b58bd34cbb2382684d) (cherry picked from commit 1a3e68de492d9f5402f0834f8249b33c1d872d71) (cherry picked from commit f9444e0e3ae9e14e6288d1d12062f3f9e4b424e8) (cherry picked from commit cc6fe4d084dff03ee2f595292fccdd11069b3c4b) (cherry picked from commit 3fa0bada14d85989dcec8469454e7244906345ff)