### PR TITLE
Fix metadata for unrouted VRFs

### DIFF
--- a/opflexagent/as_metadata_manager.py
+++ b/opflexagent/as_metadata_manager.py
@@ -91,6 +91,8 @@ STATE_FILE_EXTENSION = "state"
 STATE_FILE_NAME_FORMAT = "%s." + STATE_FILE_EXTENSION
 STATE_FILENAME_SVC = STATE_FILE_NAME_FORMAT % STATE_ANYCAST_SERVICES
 STATE_FILENAME_NETS = STATE_FILE_NAME_FORMAT % STATE_INSTANCE_NETWORKS
+COMMON_TENANT_NAME = 'common'
+UNROUTED_VRF_NAME = 'UnroutedVRF'
 
 
 def read_jsonfile(name):
@@ -346,11 +348,24 @@ class EpWatcher(FileWatcher):
         super(EpWatcher, self).__init__(
             epfiledir, epextensions, name="ep-watcher")
 
-    def gen_domain_uuid(self, tenant, name):
-        fqname = '%s|%s' % (tenant, name)
+    def gen_domain_uuid(self, *parts):
+        fqname = '|'.join(parts)
         fqhash = hashlib.md5(fqname.encode('utf-8')).hexdigest()  # nosec
         fquuid = str(uuid.UUID(fqhash))
         return fquuid
+
+    def is_common_unrouted_vrf(self, tenant, name):
+        if tenant != COMMON_TENANT_NAME or not name:
+            return False
+        return (name == UNROUTED_VRF_NAME or
+                name.endswith('_' + UNROUTED_VRF_NAME))
+
+    def gen_metadata_domain_uuid(self, ep, tenant, name):
+        if self.is_common_unrouted_vrf(tenant, name):
+            policy_space = ep.get('policy-space-name')
+            if policy_space:
+                return self.gen_domain_uuid(policy_space, tenant, name)
+        return self.gen_domain_uuid(tenant, name)
 
     def process(self, files):
         LOG.debug("EP files: %s", files)
@@ -395,7 +410,8 @@ class EpWatcher(FileWatcher):
                 if domain_name is None or domain_tenant is None:
                     continue
 
-                domain_uuid = self.gen_domain_uuid(domain_tenant, domain_name)
+                domain_uuid = self.gen_metadata_domain_uuid(
+                    ep, domain_tenant, domain_name)
                 if domain_uuid and domain_uuid not in new_svc:
                     if domain_uuid not in curr_svc:
                         updated = True

--- a/opflexagent/test/test_as_metadata_mgr.py
+++ b/opflexagent/test/test_as_metadata_mgr.py
@@ -215,6 +215,66 @@ class TestEpWatcher(base.BaseTestCase):
             ],
             write_jsonfile_patch.call_args_list)
 
+    @mock.patch('opflexagent.as_metadata_manager.write_jsonfile')
+    @mock.patch('opflexagent.as_metadata_manager.read_jsonfile')
+    @mock.patch('os.listdir',
+                return_value=['project-a.ep', 'project-b.ep'])
+    def test_process_scopes_common_unrouted_vrf_by_policy_space(
+            self, listdir_patch, read_jsonfile_patch, write_jsonfile_patch):
+        watcher = as_metadata_manager.EpWatcher.__new__(
+            as_metadata_manager.EpWatcher)
+        watcher.svcfile = '/state/anycast_services.state'
+        watcher.netsfile = '/state/instance_networks.state'
+
+        project_a_ep = {
+            'neutron-metadata-optimization': True,
+            'policy-space-name': 'project-a',
+            'domain-name': 'UnroutedVRF',
+            'domain-policy-space': 'common',
+            'neutron-network': 'net-a',
+            'anycast-return-ip': ['192.0.2.10'],
+        }
+        project_b_ep = {
+            'neutron-metadata-optimization': True,
+            'policy-space-name': 'project-b',
+            'domain-name': 'UnroutedVRF',
+            'domain-policy-space': 'common',
+            'neutron-network': 'net-b',
+            'anycast-return-ip': ['192.0.2.10'],
+        }
+        read_jsonfile_patch.side_effect = [{}, project_a_ep, project_b_ep]
+
+        watcher.process('test')
+
+        project_a_uuid = '1b9267cc-f428-22b3-4d49-24a60079ff47'
+        project_b_uuid = 'd3a6c673-a3a5-6d41-c83a-e04564b6905b'
+        self.assertEqual(
+            [
+                mock.call(
+                    watcher.netsfile,
+                    {
+                        project_a_uuid: {'192.0.2.10': 'net-a'},
+                        project_b_uuid: {'192.0.2.10': 'net-b'},
+                    }),
+                mock.call(
+                    watcher.svcfile,
+                    {
+                        project_a_uuid: {
+                            'domain-name': 'UnroutedVRF',
+                            'domain-policy-space': 'common',
+                            'next-hop-ip': '169.254.240.3',
+                            'next-hop-ipv6': 'fd00::a9fe:f003',
+                            'uuid': project_a_uuid},
+                        project_b_uuid: {
+                            'domain-name': 'UnroutedVRF',
+                            'domain-policy-space': 'common',
+                            'next-hop-ip': '169.254.240.4',
+                            'next-hop-ipv6': 'fd00::a9fe:f004',
+                            'uuid': project_b_uuid},
+                    }),
+            ],
+            write_jsonfile_patch.call_args_list)
+
 
 class TestAsMetadataManager(base.BaseTestCase):
 


### PR DESCRIPTION
When instances with overlapping IPs are scheduled to the same host, and the instances are both connected to isolated networks (no neutron router connected), the namespace proxy can't support the overlap.

This patch adds a per-project scope, so that there is a separate namespace proxy for the unrouted vrf in each project.

(cherry picked from commit 32ca14995d3ac5039f6cded6edd8773aa1a4c4af) (cherry picked from commit 1a3ba270611bc5ecfb79ab910af942ad9cff3eb2) (cherry picked from commit 05a29f1ec0ed5993c7821cded2daa837945ed802) (cherry picked from commit 34e4f1ad19569dcb638e166868d48790157493f2) (cherry picked from commit 624d0d9a57d77757a974834c0f4559e16331c52c)