### PR TITLE
Fix logging error

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -1121,4 +1121,4 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         try:
             os.remove(file_format % port_id)
         except OSError as e:
-            LOG.debug(e.message)
+            LOG.debug(e)


### PR DESCRIPTION
There is no message member in the exception. This caused an exception in the path when logging the error.

(cherry picked from commit ead4e5708d1f842a59851dfa6a4ee3134a54eb73) (cherry picked from commit ff8da5e36551d27ecbcf7f27eaf075d0b96a4e3e)