### PR TITLE
Fix logging error

### DIFF
--- a/opflexagent/utils/ep_managers/endpoint_file_manager.py
+++ b/opflexagent/utils/ep_managers/endpoint_file_manager.py
@@ -1121,4 +1121,4 @@ class EndpointFileManager(endpoint_manager_base.EndpointManagerBase):
         try:
             os.remove(file_format % port_id)
         except OSError as e:
-            LOG.debug(e.message)
+            LOG.debug(e)


### PR DESCRIPTION
There is no message member in the exception. This caused an exception in the path when logging the error.

(cherry picked from commit ead4e5708d1f842a59851dfa6a4ee3134a54eb73) (cherry picked from commit ff8da5e36551d27ecbcf7f27eaf075d0b96a4e3e) (cherry picked from commit f66a17c01aebe8d716bbb8ce9bc1f60277c558b2) (cherry picked from commit e1770800b4734b6548051b4ce2b7bdb274dbf187) (cherry picked from commit 1541e45acad4b0d39003279b180dd503657a4a53) (cherry picked from commit b381634c62b9eb36bc0e520ad8451c7158b016c2) (cherry picked from commit c803baceab7061a6e59bf788e2d39145d50cc12b) (cherry picked from commit 599e532bbc1fb4ebeaea08120522974a0c2d91bf)