### PR TITLE
Fix SNAT file management

### DIFF
--- a/opflexagent/distributed_snat_manager.py
+++ b/opflexagent/distributed_snat_manager.py
@@ -21,6 +21,7 @@ SNAT_FILE_EXTENSION = 'snat'
 SNAT_FILE_FORMAT = "%s." + SNAT_FILE_EXTENSION
 SERVICE_FILE_EXTENSION = 'service'
 SERVICE_FILE_FORMAT = "%s." + SERVICE_FILE_EXTENSION
+SERVICE_UUID = 'service-uuid'
 SNAT_CT_ZONE_MIN = 1000
 SNAT_CT_ZONE_MAX = 8191
 
@@ -101,6 +102,11 @@ class DistributedSnatManager(object):
 
         snat_uuid = hsi.get('snat_uuid') or self._stable_dist_snat_uuid(hsi)
         if not keep:
+            if self._delete_requested_by_uuid(hsi):
+                self._forget_snat_references(snat_uuid)
+                self._delete_snat_state(snat_uuid, hsi)
+                return
+
             remote_entry = self._snat_to_remote_entry.pop(snat_uuid, None)
             if snat_uuid in self._snat_to_local_entry:
                 self._render_dist_snat_files(snat_uuid)
@@ -109,17 +115,21 @@ class DistributedSnatManager(object):
                     snat_uuid, remote_entry, keep=False):
                 return
 
-            snat_info = self._snat_to_ip_range.pop(snat_uuid, None)
-            snat_ip = (snat_info.get('snat_ip')
-                       if isinstance(snat_info, dict) else None)
-            service_uuid = self._stable_dist_snat_uuid(hsi, 'service')
-            self._delete_dist_snat_files(
-                snat_uuid, snat_ip or hsi.get('host_snat_ip'),
-                service_uuid=service_uuid)
+            self._delete_snat_state(snat_uuid, hsi)
             return
 
         entry = self._build_dist_snat_entry(hsi, mapping or {}, local=False)
         if not entry:
+            return
+
+        if not self._entry_has_remote_nodes(entry):
+            self._snat_to_remote_entry.pop(snat_uuid, None)
+            if snat_uuid in self._snat_to_local_entry:
+                self._render_dist_snat_files(snat_uuid)
+                return
+            if self._clear_existing_local_snat_file_remote(snat_uuid):
+                return
+            self._delete_snat_state(snat_uuid, hsi)
             return
 
         if snat_uuid in self._snat_to_local_entry:
@@ -161,10 +171,13 @@ class DistributedSnatManager(object):
         self._snat_to_endpoints.pop(snat_uuid, None)
         self._snat_to_local_entry.pop(snat_uuid, None)
         if snat_uuid in self._snat_to_remote_entry:
-            self._snat_to_ip_range[snat_uuid] = self._entry_ip_range(
-                self._snat_to_remote_entry[snat_uuid])
-            self._render_dist_snat_files(snat_uuid)
-            return
+            remote_entry = self._snat_to_remote_entry[snat_uuid]
+            if self._entry_has_remote_nodes(remote_entry):
+                self._snat_to_ip_range[snat_uuid] = self._entry_ip_range(
+                    remote_entry)
+                self._render_dist_snat_files(snat_uuid)
+                return
+            self._snat_to_remote_entry.pop(snat_uuid, None)
 
         snat_info = self._snat_to_ip_range.pop(snat_uuid, None)
         snat_ip = (snat_info.get('snat_ip')
@@ -176,6 +189,35 @@ class DistributedSnatManager(object):
             'snat_ip': entry.get('snat_ip'),
             'start': entry.get('start'),
             'end': entry.get('end')}
+
+    def _entry_has_remote_nodes(self, entry):
+        return bool(entry and entry.get('snat_file', {}).get('remote'))
+
+    def _delete_requested_by_uuid(self, hsi):
+        return set(hsi) <= set(['snat_uuid'])
+
+    def _forget_snat_references(self, snat_uuid):
+        self._snat_to_remote_entry.pop(snat_uuid, None)
+        self._snat_to_local_entry.pop(snat_uuid, None)
+        endpoints = self._snat_to_endpoints.pop(snat_uuid, set())
+        for endpoint_uuid in list(endpoints):
+            endpoint_snats = self._endpoint_to_snats.get(endpoint_uuid)
+            if not endpoint_snats:
+                continue
+            endpoint_snats.discard(snat_uuid)
+            if endpoint_snats:
+                self._endpoint_to_snats[endpoint_uuid] = endpoint_snats
+            else:
+                self._endpoint_to_snats.pop(endpoint_uuid, None)
+
+    def _delete_snat_state(self, snat_uuid, hsi):
+        snat_info = self._snat_to_ip_range.pop(snat_uuid, None)
+        snat_ip = (snat_info.get('snat_ip')
+                   if isinstance(snat_info, dict) else None)
+        service_uuid = self._service_uuid_for_delete(snat_uuid, hsi)
+        self._delete_dist_snat_files(
+            snat_uuid, snat_ip or hsi.get('host_snat_ip'),
+            service_uuid=service_uuid)
 
     def _read_existing_snat_file(self, snat_uuid):
         try:
@@ -216,14 +258,41 @@ class DistributedSnatManager(object):
             self._write_file(snat_uuid, snat_file, self.snat_mapping_file)
         return True
 
+    def _clear_existing_local_snat_file_remote(self, snat_uuid):
+        snat_file = self._read_existing_snat_file(snat_uuid)
+        if not snat_file or not snat_file.get('local'):
+            return False
+
+        snat_file['remote'] = []
+        self._write_file(snat_uuid, snat_file, self.snat_mapping_file)
+        return True
+
     def _delete_dist_snat_files(self, snat_uuid, snat_ip=None,
                                 service_uuid=None):
+        if service_uuid is None:
+            snat_file = self._read_existing_snat_file(snat_uuid)
+            service_uuid = snat_file and snat_file.get(SERVICE_UUID)
         service_uuid = self._snat_to_service.pop(
             snat_uuid, service_uuid or snat_uuid)
         self._delete_file(snat_uuid, self.snat_mapping_file)
         if not self._service_file_is_referenced(service_uuid):
             self._delete_file(service_uuid, self.service_mapping_file)
         self._release_zone_for_snat_ip(snat_ip)
+
+    def _service_uuid_for_delete(self, snat_uuid, hsi):
+        service_uuid = self._snat_to_service.get(snat_uuid)
+        if service_uuid:
+            return service_uuid
+
+        snat_file = self._read_existing_snat_file(snat_uuid)
+        service_uuid = snat_file and snat_file.get(SERVICE_UUID)
+        if service_uuid:
+            return service_uuid
+
+        if (hsi.get('host_snat_ip') or hsi.get('external_segment_name') or
+                hsi.get('service_ip')):
+            return self._stable_dist_snat_uuid(hsi, 'service')
+        return None
 
     def _render_dist_snat_files(self, snat_uuid):
         local_entry = self._snat_to_local_entry.get(snat_uuid)
@@ -252,6 +321,12 @@ class DistributedSnatManager(object):
                 'remote', [])
             snat_file['remote'] = self._merge_remote_nodes(
                 local_remote, remote_remote)
+        service_entry = self._service_entry_for_snat(local_entry, remote_entry)
+        if service_entry:
+            service_file = service_entry.get('service_file', {})
+            service_uuid = service_file.get('uuid')
+            if service_uuid:
+                snat_file[SERVICE_UUID] = service_uuid
         return snat_file
 
     def _merge_remote_nodes(self, *remote_lists):

--- a/opflexagent/gbp_agent.py
+++ b/opflexagent/gbp_agent.py
@@ -385,18 +385,21 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
     def process_snat_update(self, snat_update):
         # TODO(thbachma): use the async model
+        requested_snats = set(snat_update or [])
+        seen_snats = set()
         snat_details_list = self.of_rpc.get_snat_details_list(
             self.context, agent_id=self.agent_id,
-            snat_ids=snat_update, host=self.host)
-        for details in snat_details_list:
+            snat_ids=requested_snats, host=self.host)
+        for details in (snat_details_list or []):
             # REVISIT(thbachma): this is not a public facing API, we will
             # move to the right method once the redesign is complete.
             keep = True
-            snat_uuid = details.get("snat_uuid")
+            snat_uuid = details and details.get("snat_uuid")
             # responses should always have the host SNAT key and UUID
             if not snat_uuid:
                 LOG.error("Received SNAT update with no SNAT data")
                 continue
+            seen_snats.add(snat_uuid)
             # If we don't have all the data, then this is a deletion.
             if not details.get("service_mac"):
                 keep = False
@@ -406,6 +409,9 @@ class GBPOpflexAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             mapping = {}
             self.ep_manager.dist_snat_manager.sync_host_snat_ip(
                 hsi, mapping, keep=keep)
+        for snat_uuid in (requested_snats - seen_snats):
+            self.ep_manager.dist_snat_manager.sync_host_snat_ip(
+                {'snat_uuid': snat_uuid}, {}, keep=False)
 
     def treat_devices_added_or_updated(self, details):
         """Process added or updated devices

--- a/opflexagent/test/test_dist_snat_mgr.py
+++ b/opflexagent/test/test_dist_snat_mgr.py
@@ -231,6 +231,77 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertFalse(os.path.exists(
             self._mapping_file_path('service', service_uuid, 'service')))
 
+    def test_sync_host_snat_ip_delete_by_uuid_after_restart(self):
+        snat_uuid = '00000000-0000-0000-0000-ffff980a0114'
+        hsi = {
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'service_vlan': 10,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'snat_uuid': snat_uuid,
+            'service_nodes': [{
+                'mac': 'dd:ee:ff:00:11:22',
+                'start_port': 20000,
+                'end_port': 20999,
+            }],
+        }
+        mapping = {
+            'vrf_tenant': 'apic_tenant',
+            'vrf_name': 'name_of_l3p',
+        }
+        self.mgr.sync_host_snat_ip(hsi, mapping, keep=True)
+        service_uuid = self.mgr._stable_dist_snat_uuid(hsi, 'service')
+
+        restarted_mgr = self._new_manager()
+        restarted_mgr.sync_host_snat_ip({'snat_uuid': snat_uuid}, {},
+                                        keep=False)
+
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('snats', snat_uuid, 'snat')))
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('service', service_uuid, 'service')))
+
+    def test_sync_host_snat_ip_delete_by_uuid_removes_local_state(self):
+        snat_uuid = '00000000-0000-0000-0000-ffff980a0114'
+        endpoint_uuid = 'port-id|aa-bb-cc-dd-ee-ff'
+        mapping = self._dist_snat_mapping([{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'service_vlan': 10,
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'dest_prefix': '0.0.0.0/0',
+            'snat_uuid': snat_uuid,
+        }])
+        dist_entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+        self.mgr.sync_endpoint(endpoint_uuid, dist_entries, {})
+        service_uuid = dist_entries[0]['service_file']['uuid']
+
+        remote_hsi = dict(mapping['host_snat_ips'][0])
+        remote_hsi['service_nodes'] = [{
+            'mac': 'dd:ee:ff:00:11:22',
+            'start_port': 20000,
+            'end_port': 20999,
+        }]
+        self.mgr.sync_host_snat_ip(remote_hsi, mapping, keep=True)
+
+        self.mgr.sync_host_snat_ip({'snat_uuid': snat_uuid}, {},
+                                   keep=False)
+
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('snats', snat_uuid, 'snat')))
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('service', service_uuid, 'service')))
+        self.assertEqual({}, self.mgr.get_dist_snat_mappings())
+
     def test_sync_host_snat_ip_update_preserves_local_file_after_restart(
             self):
         snat_uuid = '00000000-0000-0000-0000-ffff980a0114'
@@ -365,6 +436,42 @@ class TestDistributedSnatManager(base.OpflexTestBase):
         self.assertEqual(
             {'200.0.0.50': {'start': 10000, 'end': 10999}},
             self.mgr.get_dist_snat_mappings())
+
+    def test_cleanup_port_deletes_empty_remote_only_mapping(self):
+        snat_uuid = '00000000-0000-0000-0000-ffff980a0114'
+        mapping = self._dist_snat_mapping([{
+            'external_segment_name': 'EXT-DIST',
+            'host_snat_ip': '200.0.0.50',
+            'host_snat_mac': 'aa:bb:cc:00:11:55',
+            'service_mac': 'aa:bb:cc:00:22:66',
+            'service_vlan': 10,
+            'start_port': 10000,
+            'end_port': 10999,
+            'service_ip': '10.99.0.1',
+            'service_vrf': 'vrf-svc',
+            'dest_prefix': '0.0.0.0/0',
+            'snat_uuid': snat_uuid,
+        }])
+        dist_entries = self.mgr.build_dist_snat_entries(
+            mapping, {'interface-name': 'qpi'})
+        self.mgr.sync_endpoint('port-id|aa-bb-cc-dd-ee-ff',
+                               dist_entries, {})
+        service_uuid = dist_entries[0]['service_file']['uuid']
+
+        remote_hsi = dict(mapping['host_snat_ips'][0])
+        remote_hsi['service_nodes'] = []
+        self.mgr.sync_host_snat_ip(remote_hsi, mapping, keep=True)
+
+        snat_file = self._read_mapping_file('snats', snat_uuid, 'snat')
+        self.assertTrue(snat_file['local'])
+        self.assertEqual([], snat_file['remote'])
+
+        self.mgr.cleanup_port('port-id')
+
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('snats', snat_uuid, 'snat')))
+        self.assertFalse(os.path.exists(
+            self._mapping_file_path('service', service_uuid, 'service')))
 
     def test_cleanup_port_preserves_remote_only_mapping(self):
         snat_uuid = '00000000-0000-0000-0000-ffff980a0114'

--- a/opflexagent/test/test_gbp_ovs_agent.py
+++ b/opflexagent/test/test_gbp_ovs_agent.py
@@ -254,6 +254,18 @@ class TestGBPOpflexAgent(base.OpflexTestBase):
             self.agent.agent_state['configurations']['dist_snat_mappings'])
         self.assertTrue(self.agent.state_rpc.report_state.called)
 
+    def test_process_snat_update_deletes_missing_snat_detail(self):
+        snat_uuid = '00000000-0000-0000-0000-ffff980a0114'
+        self.agent.of_rpc.get_snat_details_list = mock.Mock(return_value=[])
+        self.agent.ep_manager.dist_snat_manager.sync_host_snat_ip = (
+            mock.Mock())
+
+        self.agent.process_snat_update(set([snat_uuid]))
+
+        self.agent.ep_manager.dist_snat_manager.sync_host_snat_ip.\
+            assert_called_once_with({'snat_uuid': snat_uuid}, {},
+                                    keep=False)
+
     def test_subnet_has_updates(self):
         fake_sub = {'tenant_id': 'tenant-id', 'id': 'someid'}
         polling_manager = mock.Mock()


### PR DESCRIPTION
The service and SNAT files weren't being maintained correctly when local and remote ports were being removed.